### PR TITLE
Implement Play Asset Delivery for ONNX models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.15] - 2026-04-29
+
+### Changed
+
+- **Play Asset Delivery for ONNX models on Android.** The two large `.onnx` model files (~152 MB audio classifier + ~6 MB geo model) are now shipped via an install-time Play Asset Delivery pack (`models_pack`) instead of being bundled inside the base module. This keeps the base AAB comfortably under Google Play's 200 MB compressed download limit while still being fully offline — the pack is downloaded together with the app at install time and unpacked to disk. Sideload APK builds (GitHub releases) are unaffected: the models continue to live in `flutter_assets` and are extracted to the app documents directory on first launch exactly as before.
+- **Centralized model file resolution.** A new `AssetPackService` transparently resolves each model file from either the asset pack (Play Store builds) or `rootBundle` extraction (sideload builds). All four model-loading call sites (Live, Survey, File Analysis, Explore geo-model) now go through this single resolver, removing duplicated extraction logic.
+
 ## [0.7.14] - 2026-04-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
   <img src="https://img.shields.io/badge/flutter-%3E%3D3.0-blue.svg" alt="Flutter">
   <img src="https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Windows-green.svg" alt="Platforms">
-  <img src="https://img.shields.io/badge/version-0.7.14-orange.svg" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.7.15-orange.svg" alt="Version">
   <img src="https://img.shields.io/badge/species-5%2C250-brightgreen.svg" alt="Species: 5,250">
 </p>
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -50,6 +50,23 @@ android {
         }
     }
 
+    // ── Asset pack split ──────────────────────────────────────────────
+    //
+    // The `models_pack` install-time asset pack ships the two large ONNX
+    // model files (~152 MB + ~6 MB) outside the base module so that the
+    // compressed base download stays under Google Play's 200 MB limit.
+    //
+    // Asset packs are inherently App Bundle only: `bundleRelease` includes
+    // the pack, `assembleRelease` ignores it. The standalone APK we build
+    // for sideload / GitHub releases therefore keeps the .onnx files in
+    // `flutter_assets` and remains fully self-contained — no asset pack,
+    // no online download, no Play services required.
+    //
+    // The Dart-side `AssetPackService` resolves models from the pack when
+    // available, and falls back to extracting them from `rootBundle` on
+    // sideload installs. Both paths run fully offline at runtime.
+    assetPacks = [":models_pack"]
+
     signingConfigs {
         release {
             keyAlias keystoreProperties['keyAlias']
@@ -75,4 +92,58 @@ flutter {
 
 dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.4'
+
+    // Play Asset Delivery — used at runtime to resolve the install-time
+    // `models_pack` asset pack's on-device path. The library degrades
+    // gracefully on sideload APKs (no Play Store install): the API simply
+    // returns null for any pack lookup, and we fall back to extracting
+    // models from `rootBundle`.
+    implementation 'com.google.android.play:asset-delivery:2.2.2'
+}
+
+// ── Strip *.onnx from base module assets when building the App Bundle ──
+//
+// The asset pack ships the .onnx files for AAB builds. If we left them
+// in `flutter_assets` as well, the base module would still be ~218 MB
+// compressed and Google Play would reject the upload (>200 MB limit).
+//
+// Asset flow on the Flutter Android pipeline:
+//   1. mergeReleaseAssets       — merges Android library assets
+//   2. copyFlutterAssetsRelease — Flutter copies its assets into the
+//                                  same `intermediates/assets/release/`
+//   3. packageReleaseBundle     — packs the AAB (bundle build only)
+//      packageRelease           — packs the APK   (apk build only)
+//
+// We hook `doLast` to `copyFlutterAssetsRelease` (which runs for both
+// AAB and APK builds), and only strip when the current task graph
+// contains `packageReleaseBundle`. APK builds therefore retain the
+// self-contained .onnx files automatically.
+//
+// `copyFlutterAssetsRelease` is also marked non-cacheable so a
+// follow-up APK build always re-copies the .onnx files we deleted.
+afterEvaluate {
+    tasks.matching { it.name == 'copyFlutterAssetsRelease' }.configureEach { copyTask ->
+        copyTask.outputs.upToDateWhen { false }
+        copyTask.doLast {
+            if (!gradle.taskGraph.hasTask(':app:packageReleaseBundle')) {
+                logger.info("[asset-pack] APK build detected — keeping .onnx in flutter_assets")
+                return
+            }
+            def root = file("${buildDir}/intermediates/assets/release")
+            if (!root.exists()) {
+                logger.warn("[asset-pack] merged assets dir not found: ${root}")
+                return
+            }
+            def removed = 0
+            def freedBytes = 0L
+            fileTree(dir: root, include: '**/*.onnx').each { f ->
+                freedBytes += f.length()
+                if (f.delete()) removed++
+            }
+            def freedMb = (freedBytes / 1024.0 / 1024.0).round(1)
+            logger.lifecycle(
+                "[asset-pack] stripped ${removed} .onnx file(s) (${freedMb} MB) " +
+                "from base module — shipped via models_pack instead")
+        }
+    }
 }

--- a/android/app/src/main/kotlin/com/birdnet/birdnet_live/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/birdnet/birdnet_live/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.birdnet.birdnet_live
 
 import android.view.WindowManager
+import com.google.android.play.core.assetpacks.AssetPackManagerFactory
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
@@ -9,6 +10,7 @@ import kotlinx.coroutines.*
 class MainActivity: FlutterActivity() {
     private val WAKELOCK_CHANNEL = "com.birdnet/wakelock"
     private val AUDIO_DECODER_CHANNEL = "com.birdnet/audio_decoder"
+    private val ASSET_PACK_CHANNEL = "com.birdnet/asset_pack"
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
@@ -49,6 +51,35 @@ class MainActivity: FlutterActivity() {
                                 result.error("DECODE_ERROR", e.message, null)
                             }
                         }
+                    }
+                }
+                else -> result.notImplemented()
+            }
+        }
+
+        // Asset pack channel — resolves the on-device path of an
+        // install-time Play Asset Delivery pack. Used to locate the ONNX
+        // model files in App Bundle (AAB) installs from the Play Store.
+        // On sideload APK installs there is no asset pack, so the call
+        // returns null and the Dart side falls back to extracting the
+        // models from `rootBundle`.
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, ASSET_PACK_CHANNEL).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "getPackPath" -> {
+                    val packName = call.argument<String>("packName")
+                    if (packName.isNullOrBlank()) {
+                        result.error("INVALID_ARG", "Missing 'packName'", null)
+                        return@setMethodCallHandler
+                    }
+                    try {
+                        val mgr = AssetPackManagerFactory.getInstance(applicationContext)
+                        val location = mgr.getPackLocation(packName)
+                        result.success(location?.assetsPath())
+                    } catch (e: Throwable) {
+                        // Sideload APK without Play Asset Delivery support,
+                        // pack not installed, or any other failure: report
+                        // null so the Dart side falls back to rootBundle.
+                        result.success(null)
                     }
                 }
                 else -> result.notImplemented()

--- a/android/models_pack/.gitignore
+++ b/android/models_pack/.gitignore
@@ -1,0 +1,5 @@
+# The pack's assets directory is populated at build time by the
+# `syncOnnxModels` task in `build.gradle` from the workspace's
+# `assets/models/*.onnx`. Keep the large model files out of source control.
+src/main/assets/
+build/

--- a/android/models_pack/build.gradle
+++ b/android/models_pack/build.gradle
@@ -1,0 +1,54 @@
+// =============================================================================
+// models_pack — Install-time asset pack for the BirdNET ONNX models
+// =============================================================================
+//
+// Ships the two large ONNX model files (~152 MB audio classifier + ~6 MB
+// geo model) outside of the App Bundle's base module so that the
+// compressed base download stays under Google Play's 200 MB limit.
+//
+// Delivery type is "install-time": the pack is downloaded together with
+// the app at install time and unpacked to a directory on the device.
+// The app reads the model files directly from that directory at runtime
+// via AssetPackManager — no network access is required.
+//
+// Asset packs are only included in App Bundle (`bundle*`) builds. APK
+// builds (`assemble*`) ignore the pack entirely; the standalone APK we
+// ship for sideload / GitHub releases keeps the .onnx files inside
+// `assets/models/` (Flutter assets) so it remains fully self-contained.
+//
+// To avoid duplicating the large .onnx files in source control, the
+// pack's assets directory (`src/main/assets/models/`) is gitignored and
+// populated at build time by the `syncOnnxModels` task below, which
+// mirrors `<repo>/assets/models/*.onnx`.
+// =============================================================================
+
+plugins {
+    id 'com.android.asset-pack'
+}
+
+assetPack {
+    packName = "models_pack"
+    dynamicDelivery {
+        deliveryType = "install-time"
+    }
+}
+
+// Mirror the ONNX model files from the Flutter assets directory into the
+// pack at build time. `assets/models/` remains the single source of truth.
+tasks.register('syncOnnxModels', Sync) {
+    from file("${rootDir}/../assets/models")
+    include "*.onnx"
+    into file("${projectDir}/src/main/assets/models")
+}
+
+// Asset pack modules expose a small set of dynamically named tasks
+// (e.g. `assembleAssetPackRelease`, `linkAssetPackManifestRelease`,
+// `packageAssetPackRelease`). Make all of them depend on the sync so the
+// .onnx files are guaranteed to be in place before any pack processing.
+afterEvaluate {
+    tasks.configureEach { task ->
+        if (task.name == 'syncOnnxModels') return
+        if (task.name.startsWith('clean')) return
+        task.dependsOn 'syncOnnxModels'
+    }
+}

--- a/android/models_pack/src/main/AndroidManifest.xml
+++ b/android/models_pack/src/main/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:dist="http://schemas.android.com/apk/distribution"
+    package="com.birdnet.birdnet_live.models_pack">
+
+    <dist:module
+        dist:type="asset-pack">
+        <dist:fusing dist:include="true" />
+        <dist:delivery>
+            <dist:install-time />
+        </dist:delivery>
+    </dist:module>
+
+</manifest>

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -23,3 +23,4 @@ plugins {
 }
 
 include ":app"
+include ":models_pack"

--- a/lib/core/services/asset_pack_service.dart
+++ b/lib/core/services/asset_pack_service.dart
@@ -1,0 +1,150 @@
+// =============================================================================
+// AssetPackService — Resolves ONNX model files across release flows
+// =============================================================================
+//
+// BirdNET Live ships in two release shapes:
+//
+//   1. **Play Store (AAB)** — the two large `.onnx` model files (~152 MB
+//      audio classifier + ~6 MB geo model) live in an *install-time*
+//      Play Asset Delivery pack named `models_pack`. The pack is
+//      downloaded together with the app at install time and unpacked
+//      into a directory on the device. The Play Console requires the
+//      base module download to stay under 200 MB compressed, which is
+//      why we split the models out.
+//
+//   2. **Sideload APK (GitHub release)** — there is no asset pack. The
+//      `.onnx` files are bundled inside `flutter_assets` exactly as
+//      before. On first launch we extract them to the app's documents
+//      directory so they can be memory-mapped by ONNX Runtime.
+//
+// Both flows are fully **offline** — no network access is required at
+// install or runtime.
+//
+// Callers should always go through [resolveModelPath] rather than
+// hand-rolling the extraction logic. The resolver picks the right source
+// transparently per file:
+//
+//   • If the asset pack is present and contains the file → return its
+//     on-device path directly (no copy needed; install-time pack files
+//     are already plain files on disk).
+//   • Otherwise → extract the file from `rootBundle` to the documents
+//     directory under `<fileName>_v<version>` (idempotent, mirrors the
+//     historical behavior).
+//
+// On non-Android platforms (iOS, Windows, tests) the pack is always
+// absent and the bundle fallback is used.
+// =============================================================================
+
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:path_provider/path_provider.dart';
+
+import '../constants/app_constants.dart';
+
+class AssetPackService {
+  AssetPackService._();
+
+  static const MethodChannel _channel = MethodChannel('com.birdnet/asset_pack');
+
+  /// Name of the install-time pack defined in `android/models_pack/`.
+  static const String _packName = 'models_pack';
+
+  /// Cached lookup result. Pack location never changes during a process
+  /// lifetime, so we resolve once and reuse.
+  static String? _cachedPackPath;
+  static bool _resolved = false;
+
+  /// Returns the on-device path of the install-time asset pack's
+  /// `assets/` directory, or `null` if the pack is unavailable (sideload
+  /// APK, non-Android platform, or platform channel error).
+  static Future<String?> getPackPath() async {
+    if (_resolved) return _cachedPackPath;
+    if (!_isAndroid) {
+      _resolved = true;
+      return null;
+    }
+    try {
+      final result = await _channel.invokeMethod<String>(
+        'getPackPath',
+        {'packName': _packName},
+      );
+      _cachedPackPath = result;
+      if (result != null) {
+        debugPrint('[AssetPackService] models_pack at $result');
+      } else {
+        debugPrint(
+          '[AssetPackService] models_pack not present — sideload mode',
+        );
+      }
+    } catch (e) {
+      debugPrint('[AssetPackService] platform channel error: $e');
+      _cachedPackPath = null;
+    }
+    _resolved = true;
+    return _cachedPackPath;
+  }
+
+  /// Resolve a model file living at `assets/models/<fileName>` to an
+  /// absolute on-device path suitable for passing to ONNX Runtime.
+  ///
+  /// [fileName] — bare file name, e.g. `BirdNET+_V3.0-...-FP16.onnx`.
+  /// [version] — model version string used to suffix the extracted
+  ///   sideload copy (`<fileName>_v<version>`), so model upgrades
+  ///   trigger a fresh extraction.
+  static Future<String> resolveModelPath({
+    required String fileName,
+    required String version,
+  }) async {
+    final packPath = await getPackPath();
+    if (packPath != null) {
+      final candidate = File('$packPath/models/$fileName');
+      if (candidate.existsSync()) {
+        return candidate.path;
+      }
+      debugPrint(
+        '[AssetPackService] pack present but missing $fileName — '
+        'falling back to rootBundle extraction',
+      );
+    }
+    return _extractFromBundle(fileName, version);
+  }
+
+  /// Fallback path: extract the model bytes from `rootBundle` into the
+  /// app's documents directory the first time the app runs (or after a
+  /// version bump). Used by sideload APK installs.
+  static Future<String> _extractFromBundle(
+    String fileName,
+    String version,
+  ) async {
+    final appDir = await getApplicationDocumentsDirectory();
+    final versionedName = '${fileName}_v$version';
+    final modelFile = File('${appDir.path}/$versionedName');
+    if (!modelFile.existsSync()) {
+      debugPrint(
+        '[AssetPackService] extracting $fileName v$version to '
+        '${modelFile.path}',
+      );
+      final assetPath = '${AppConstants.modelAssetsDir}/$fileName';
+      final data = await rootBundle.load(assetPath);
+      await modelFile.writeAsBytes(
+        data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
+        flush: true,
+      );
+      debugPrint(
+        '[AssetPackService] extraction complete '
+        '(${modelFile.lengthSync()} bytes)',
+      );
+    }
+    return modelFile.path;
+  }
+
+  static bool get _isAndroid {
+    try {
+      return Platform.isAndroid;
+    } catch (_) {
+      return false;
+    }
+  }
+}

--- a/lib/features/explore/explore_providers.dart
+++ b/lib/features/explore/explore_providers.dart
@@ -25,15 +25,14 @@
 // =============================================================================
 
 import 'dart:convert';
-import 'dart:io';
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:path_provider/path_provider.dart';
 
 import '../../core/constants/app_constants.dart';
+import '../../core/services/asset_pack_service.dart';
 import '../../shared/models/taxonomy_species.dart';
 import '../../shared/providers/settings_providers.dart';
 import '../../shared/services/species_description_service.dart';
@@ -156,28 +155,19 @@ final geoModelProvider = FutureProvider<GeoModel>((ref) async {
     '${AppConstants.modelAssetsDir}/$labelsFile',
   );
 
-  // Ensure ONNX file is on disk (same pattern as the audio model).
-  // Use modelVersion from config to detect when asset has been updated.
+  // Resolve the geo-model ONNX file via the install-time asset pack
+  // (Play Store AAB) or fall back to extracting from rootBundle (sideload
+  // APK). Use modelVersion from config to detect when the asset has been
+  // updated so a fresh extraction kicks in.
   final modelVersion = geoConfig['version'] as String? ?? '0';
-  final appDir = await getApplicationDocumentsDirectory();
-  final versionedName = '${modelFile}_v$modelVersion';
-  final onnxFile = File('${appDir.path}/$versionedName');
-
-  if (!onnxFile.existsSync()) {
-    debugPrint('[geoModelProvider] extracting geo model v$modelVersion '
-        'to ${onnxFile.path}');
-    final data = await rootBundle.load(
-      '${AppConstants.modelAssetsDir}/$modelFile',
-    );
-    await onnxFile.writeAsBytes(
-      data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
-      flush: true,
-    );
-  }
+  final onnxPath = await AssetPackService.resolveModelPath(
+    fileName: modelFile,
+    version: modelVersion,
+  );
 
   final geoModel = GeoModel();
   geoModel.loadLabels(labelsText);
-  await geoModel.loadModel(onnxFile.path);
+  await geoModel.loadModel(onnxPath);
 
   debugPrint('[geoModelProvider] geo model ready '
       '(${geoModel.labels.length} species)');

--- a/lib/features/file_analysis/file_analysis_controller.dart
+++ b/lib/features/file_analysis/file_analysis_controller.dart
@@ -35,9 +35,9 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
-import 'package:path_provider/path_provider.dart';
 
 import '../../core/constants/app_constants.dart';
+import '../../core/services/asset_pack_service.dart';
 import '../inference/inference_isolate.dart';
 import '../inference/model_config.dart';
 import '../inference/species_filter.dart';
@@ -193,9 +193,11 @@ class FileAnalysisController {
         fullConfig['audioModel'] as Map<String, dynamic>,
       );
 
-      final modelFilePath = await _ensureModelOnDisk(
-        _config!.onnx.modelFile,
-        _config!.version,
+      // Resolve via install-time asset pack (Play Store AAB) or fall
+      // back to extracting from rootBundle (sideload APK).
+      final modelFilePath = await AssetPackService.resolveModelPath(
+        fileName: _config!.onnx.modelFile,
+        version: _config!.version,
       );
 
       final labelsAssetPath =
@@ -216,23 +218,6 @@ class FileAnalysisController {
     }
 
     _notifyListeners();
-  }
-
-  Future<String> _ensureModelOnDisk(String fileName, String version) async {
-    final appDir = await getApplicationDocumentsDirectory();
-    final versionedName = '${fileName}_v$version';
-    final modelFile = File('${appDir.path}/$versionedName');
-
-    if (!modelFile.existsSync()) {
-      final assetPath = '${AppConstants.modelAssetsDir}/$fileName';
-      final data = await rootBundle.load(assetPath);
-      await modelFile.writeAsBytes(
-        data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
-        flush: true,
-      );
-    }
-
-    return modelFile.path;
   }
 
   // ── File inspection ───────────────────────────────────────────────────

--- a/lib/features/live/live_controller.dart
+++ b/lib/features/live/live_controller.dart
@@ -33,14 +33,13 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:just_audio/just_audio.dart';
-import 'package:path_provider/path_provider.dart';
 
 import '../../core/constants/app_constants.dart';
+import '../../core/services/asset_pack_service.dart';
 import '../../core/services/memory_monitor.dart';
 import '../audio/ring_buffer.dart';
 import '../inference/inference_isolate.dart';
@@ -220,10 +219,11 @@ class LiveController {
       );
       debugPrint('[LiveController] config loaded: ${_config!.onnx.modelFile}');
 
-      // Ensure model file exists on the filesystem.
-      final modelFilePath = await _ensureModelOnDisk(
-        _config!.onnx.modelFile,
-        _config!.version,
+      // Resolve the model path: install-time asset pack (Play Store AAB)
+      // or fallback to extracting from rootBundle (sideload APK).
+      final modelFilePath = await AssetPackService.resolveModelPath(
+        fileName: _config!.onnx.modelFile,
+        version: _config!.version,
       );
       debugPrint('[LiveController] model on disk: $modelFilePath');
 
@@ -249,31 +249,6 @@ class LiveController {
     }
 
     _notifyListeners();
-  }
-
-  /// Copy the model asset to the app's documents directory if it doesn't
-  /// already exist on disk, and return the absolute file path.
-  Future<String> _ensureModelOnDisk(String fileName, String version) async {
-    final appDir = await getApplicationDocumentsDirectory();
-    final versionedName = '${fileName}_v$version';
-    final modelFile = File('${appDir.path}/$versionedName');
-
-    if (!modelFile.existsSync()) {
-      debugPrint('[LiveController] extracting model to ${modelFile.path} …');
-      final assetPath = '${AppConstants.modelAssetsDir}/$fileName';
-      final data = await rootBundle.load(assetPath);
-      await modelFile.writeAsBytes(
-        data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
-        flush: true,
-      );
-      debugPrint('[LiveController] extraction complete '
-          '(${modelFile.lengthSync()} bytes)');
-    } else {
-      debugPrint('[LiveController] model already on disk '
-          '(${modelFile.lengthSync()} bytes)');
-    }
-
-    return modelFile.path;
   }
 
   // ── Session lifecycle ─────────────────────────────────────────────────

--- a/lib/features/survey/survey_controller.dart
+++ b/lib/features/survey/survey_controller.dart
@@ -38,6 +38,7 @@ import 'survey_notification.dart';
 import 'survey_alert_coordinator.dart';
 
 import '../../core/constants/app_constants.dart';
+import '../../core/services/asset_pack_service.dart';
 import '../../core/services/memory_monitor.dart';
 import '../audio/ring_buffer.dart';
 import '../inference/inference_isolate.dart';
@@ -253,9 +254,11 @@ class SurveyController {
         fullConfig['audioModel'] as Map<String, dynamic>,
       );
 
-      final modelFilePath = await _ensureModelOnDisk(
-        _config!.onnx.modelFile,
-        _config!.version,
+      // Resolve via install-time asset pack (Play Store AAB) or fall
+      // back to extracting from rootBundle (sideload APK).
+      final modelFilePath = await AssetPackService.resolveModelPath(
+        fileName: _config!.onnx.modelFile,
+        version: _config!.version,
       );
 
       final labelsAssetPath =
@@ -278,23 +281,7 @@ class SurveyController {
     _notifyListeners();
   }
 
-  Future<String> _ensureModelOnDisk(String fileName, String version) async {
-    final appDir = await getApplicationDocumentsDirectory();
-    final versionedName = '${fileName}_v$version';
-    final modelFile = File('${appDir.path}/$versionedName');
-
-    if (!modelFile.existsSync()) {
-      final assetPath = '${AppConstants.modelAssetsDir}/$fileName';
-      final data = await rootBundle.load(assetPath);
-      await modelFile.writeAsBytes(
-        data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
-        flush: true,
-      );
-    }
-    return modelFile.path;
-  }
-
-  // ── Session lifecycle ───────────────────────────────────────────────────
+  // ── Session lifecycle ─────────────────────────────────────────────────
 
   /// Start a new survey session.
   Future<void> startSurvey({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: birdnet_live
 description: "Real-time bird species identification using on-device ONNX inference"
 publish_to: 'none'
-version: 0.7.14+90
+version: 0.7.15+91
 
 environment:
   sdk: ^3.6.2


### PR DESCRIPTION
Introduce Play Asset Delivery for ONNX models to optimize app size and loading. Refactor model loading logic to centralize file resolution, ensuring models are accessed from the asset pack for Play Store builds while maintaining functionality for sideloaded APKs. Update version to 0.7.15 and changelog accordingly.