### PR TITLE
Replace onnxruntime with flutter_onnxruntime for compliance and refactor tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-04-29
+
+### Changed
+
+- **ONNX runtime swapped for Play Store 16 KB page-size compliance.** Replaced the unmaintained `onnxruntime ^1.4.1` package (gtbluesky, FFI-based, ships ORT 1.15 with 4 KB-aligned `libonnxruntime.so`) with the actively-maintained `flutter_onnxruntime ^1.7.0` package (masicai, MethodChannel-based, ships ORT 1.22 with 16 KB-aligned native libraries since 1.5.1). Verified `libonnxruntime.so` and `libonnxruntime4j_jni.so` in the release App Bundle now report `p_align = 0x4000` (16 KB) in their ELF LOAD program headers, satisfying Google Play's 16 KB memory-page-size requirement on Android 15+ devices.
+- **Inference architecture simplified.** The audio classifier no longer runs in a Dart background isolate. The new runtime plugin uses a Kotlin/Java `BackgroundTaskQueue` to run native ONNX inference off the platform thread, so the UI stays responsive without an isolate hop. The `InferenceIsolate` wrapper preserves its public API (`start`, `stop`, `infer`, `resetPooling`, `setMaxPoolWindows`, `isRunning`) but now delegates to `InferenceService` directly on the root isolate. This removes a class of message-passing bugs and reduces memory overhead.
+- **Flutter SDK upgraded to 3.41.8 (Dart 3.11.5)** to satisfy the new runtime plugin's Dart 3.7 minimum. Kotlin Gradle plugin bumped from 1.9.22 to 2.1.0.
+- All `GeoModel.predict`, `GeoModel.predictAllWeeks`, `GeoModel.expectedSpecies`, and `GeoModel.geoScoresForFilter` calls are now `async` (the new runtime exposes only async APIs). All call sites updated.
+
 ## [0.8.3] - 2026-04-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
   <img src="https://img.shields.io/badge/flutter-%3E%3D3.0-blue.svg" alt="Flutter">
   <img src="https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Windows-green.svg" alt="Platforms">
-  <img src="https://img.shields.io/badge/version-0.8.3-orange.svg" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.9.0-orange.svg" alt="Version">
   <img src="https://img.shields.io/badge/species-5%2C250-brightgreen.svg" alt="Species: 5,250">
 </p>
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -55,7 +55,7 @@ android {
         applicationId = "de.tu_chemnitz.mi.kahst.birdnet_live"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = 23
+        minSdkVersion = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -23,7 +23,7 @@ plugins {
     // 16 KB memory-page-size compatibility check (Android 15+ devices).
     // See: https://developer.android.com/guide/practices/page-sizes
     id "com.android.application" version "8.7.3" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.22" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 
 include ":app"

--- a/integration_test/geo_soundscape_test.dart
+++ b/integration_test/geo_soundscape_test.dart
@@ -43,8 +43,7 @@ void main() {
     final audioModelData =
         await rootBundle.load('assets/models/${config.onnx.modelFile}');
     final audioTempDir = Directory.systemTemp;
-    final audioTempFile =
-        File('${audioTempDir.path}/audio_model_test.onnx');
+    final audioTempFile = File('${audioTempDir.path}/audio_model_test.onnx');
     await audioTempFile.writeAsBytes(audioModelData.buffer.asUint8List(
         audioModelData.offsetInBytes, audioModelData.lengthInBytes));
     await audioModel.loadModelFromFile(

--- a/integration_test/geo_soundscape_test.dart
+++ b/integration_test/geo_soundscape_test.dart
@@ -42,10 +42,13 @@ void main() {
     audioModel = ClassifierModel();
     final audioModelData =
         await rootBundle.load('assets/models/${config.onnx.modelFile}');
-    final audioModelBytes = audioModelData.buffer.asUint8List(
-        audioModelData.offsetInBytes, audioModelData.lengthInBytes);
-    await audioModel.loadModel(
-      audioModelBytes,
+    final audioTempDir = Directory.systemTemp;
+    final audioTempFile =
+        File('${audioTempDir.path}/audio_model_test.onnx');
+    await audioTempFile.writeAsBytes(audioModelData.buffer.asUint8List(
+        audioModelData.offsetInBytes, audioModelData.lengthInBytes));
+    await audioModel.loadModelFromFile(
+      audioTempFile.path,
       inputName: config.onnx.inputName,
       predictionsName: config.onnx.predictionsName,
       embeddingsName: config.onnx.embeddingsName,
@@ -79,15 +82,15 @@ void main() {
     );
   });
 
-  tearDownAll(() {
-    audioModel.dispose();
-    geoModel.dispose();
+  tearDownAll(() async {
+    await audioModel.dispose();
+    await geoModel.dispose();
   });
 
   testWidgets('Geo-model inference (Berlin, week 26) yields sensible results',
       (tester) async {
     // Berlin: 52.52°N, 13.40°E
-    final probabilities = geoModel.predict(
+    final probabilities = await geoModel.predict(
       latitude: 52.52,
       longitude: 13.40,
       week: 26,

--- a/integration_test/memory_stress_test.dart
+++ b/integration_test/memory_stress_test.dart
@@ -60,10 +60,20 @@ void main() {
     final modelData = await rootBundle.load(
       'assets/models/${config.onnx.modelFile}',
     );
+    final appDirEarly = await getApplicationDocumentsDirectory();
+    tempDir = '${appDirEarly.path}/mem_stress_test';
+    await Directory(tempDir).create(recursive: true);
+    final audioOnnxPath = '$tempDir/audio_model.onnx';
+    if (!File(audioOnnxPath).existsSync()) {
+      await File(audioOnnxPath).writeAsBytes(
+        modelData.buffer
+            .asUint8List(modelData.offsetInBytes, modelData.lengthInBytes),
+        flush: true,
+      );
+    }
     audioModel = ClassifierModel();
-    await audioModel.loadModel(
-      modelData.buffer
-          .asUint8List(modelData.offsetInBytes, modelData.lengthInBytes),
+    await audioModel.loadModelFromFile(
+      audioOnnxPath,
       inputName: config.onnx.inputName,
       predictionsName: config.onnx.predictionsName,
       embeddingsName: config.onnx.embeddingsName,
@@ -83,10 +93,6 @@ void main() {
     );
 
     // Extract geo ONNX to temp path.
-    final appDir = await getApplicationDocumentsDirectory();
-    tempDir = '${appDir.path}/mem_stress_test';
-    await Directory(tempDir).create(recursive: true);
-
     final geoOnnxPath = '$tempDir/geo_model.onnx';
     if (!File(geoOnnxPath).existsSync()) {
       final geoData = await rootBundle.load(
@@ -227,7 +233,7 @@ void main() {
     final phase3Baseline = MemoryMonitor.logOnce(tag: 'geo-start');
 
     // Simulate what happens at session start: predictAllWeeks.
-    geoModel.predictAllWeeks(latitude: 52.5, longitude: 13.4);
+    await geoModel.predictAllWeeks(latitude: 52.5, longitude: 13.4);
 
     final afterGeo = MemoryMonitor.logOnce(tag: 'geo-end');
     debugPrint('[MemStress] Geo 48-week RSS growth: '

--- a/integration_test/model_output_test.dart
+++ b/integration_test/model_output_test.dart
@@ -60,8 +60,12 @@ void main() {
     final modelData = await rootBundle.load(
       'assets/models/${config.onnx.modelFile}',
     );
-    await model.loadModel(
-      modelData.buffer.asUint8List(),
+    final tempDir = Directory.systemTemp;
+    final tempModel = File('${tempDir.path}/model_output_test.onnx');
+    await tempModel.writeAsBytes(modelData.buffer.asUint8List(
+        modelData.offsetInBytes, modelData.lengthInBytes));
+    await model.loadModelFromFile(
+      tempModel.path,
       inputName: config.onnx.inputName,
       predictionsName: config.onnx.predictionsName,
       embeddingsName: config.onnx.embeddingsName,
@@ -86,8 +90,8 @@ void main() {
     allAudioSamples = audioBytes.buffer.asFloat32List();
   });
 
-  tearDownAll(() {
-    model.dispose();
+  tearDownAll(() async {
+    await model.dispose();
   });
 
   // -------------------------------------------------------------------------

--- a/integration_test/model_output_test.dart
+++ b/integration_test/model_output_test.dart
@@ -62,8 +62,8 @@ void main() {
     );
     final tempDir = Directory.systemTemp;
     final tempModel = File('${tempDir.path}/model_output_test.onnx');
-    await tempModel.writeAsBytes(modelData.buffer.asUint8List(
-        modelData.offsetInBytes, modelData.lengthInBytes));
+    await tempModel.writeAsBytes(modelData.buffer
+        .asUint8List(modelData.offsetInBytes, modelData.lengthInBytes));
     await model.loadModelFromFile(
       tempModel.path,
       inputName: config.onnx.inputName,

--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,4 +1,3 @@
 arb-dir: lib/l10n
 template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
-synthetic-package: false

--- a/lib/features/explore/explore_providers.dart
+++ b/lib/features/explore/explore_providers.dart
@@ -229,7 +229,7 @@ final exploreSpeciesProvider =
   final currentWeek = GeoModel.dateTimeToWeek(DateTime.now());
 
   // Run all 48 weeks directly (no isolate — small model, fast inference).
-  final allWeeks = geoModel.predictAllWeeks(
+  final allWeeks = await geoModel.predictAllWeeks(
     latitude: location.latitude,
     longitude: location.longitude,
   );
@@ -299,7 +299,7 @@ final geoScoresProvider = FutureProvider<Map<String, double>?>((ref) async {
   if (location == null) return null;
 
   final week = GeoModel.dateTimeToWeek(DateTime.now());
-  return geoModel.geoScoresForFilter(
+  return await geoModel.geoScoresForFilter(
     latitude: location.latitude,
     longitude: location.longitude,
     week: week,

--- a/lib/features/file_analysis/file_analysis_screen.dart
+++ b/lib/features/file_analysis/file_analysis_screen.dart
@@ -291,7 +291,7 @@ class _FileAnalysisScreenState extends ConsumerState<FileAnalysisScreen> {
         geoSpeciesNames = (await ref.read(geoModelSpeciesNamesProvider.future));
         final refDate = _recordingDate ?? DateTime.now();
         final week = _weekNumber(refDate);
-        geoScores = geoModel.predict(
+        geoScores = await geoModel.predict(
           latitude: _latitude!,
           longitude: _longitude!,
           week: week,

--- a/lib/features/inference/classifier_model.dart
+++ b/lib/features/inference/classifier_model.dart
@@ -1,5 +1,5 @@
 // =============================================================================
-// Classifier Model — ONNX Runtime wrapper for species classification
+// Classifier Model — flutter_onnxruntime wrapper for species classification
 // =============================================================================
 //
 // Encapsulates all ONNX-specific logic: model loading, session management,
@@ -25,13 +25,13 @@
 //
 // ### Threading
 //
-// The `onnxruntime` package uses FFI, so sessions can be created inside
-// Dart [Isolate]s.  The [InferenceIsolate] class in this feature handles
-// isolate lifecycle; this service is the low-level model wrapper.
+// `flutter_onnxruntime` uses platform channels and runs native inference on
+// a background thread (BackgroundTaskQueue), so calls do not block the UI.
+// All Dart-side calls must happen on the root isolate.
 //
 // ### Lifecycle
 //
-// 1. Call [loadModel] or [loadModelFromFile] to load the `.onnx` model.
+// 1. Call [loadModelFromFile] to load the `.onnx` model.
 // 2. Call [predict] as many times as needed.
 // 3. Call [dispose] when finished to free native resources.
 // =============================================================================
@@ -39,23 +39,23 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
-import 'package:onnxruntime/onnxruntime.dart';
+import 'package:flutter_onnxruntime/flutter_onnxruntime.dart';
 
 /// Low-level wrapper around an ONNX classification model.
 ///
 /// Handles session creation, input tensor construction, inference, and
 /// resource cleanup.  Not intended for direct UI consumption — use
-/// [InferenceService] or [InferenceIsolate] instead.
+/// [InferenceService] instead.
 class ClassifierModel {
-  /// Creates a new model instance.  Call [loadModel] to initialize.
+  /// Creates a new model instance.  Call [loadModelFromFile] to initialize.
   ClassifierModel();
 
   // ---------------------------------------------------------------------------
   // State
   // ---------------------------------------------------------------------------
 
+  final OnnxRuntime _ort = OnnxRuntime();
   OrtSession? _session;
-  bool _envInitialized = false;
 
   /// Tensor name used for the audio input.
   String _inputName = 'input';
@@ -67,12 +67,6 @@ class ClassifierModel {
   /// produce embeddings.
   String? _embeddingsName = 'embeddings';
 
-  /// Index of the predictions tensor in the session's output list.
-  int _predictionsIndex = 0;
-
-  /// Index of the embeddings tensor in the session's output list, or -1.
-  int _embeddingsIndex = -1;
-
   /// Whether a model is currently loaded and ready for inference.
   bool get isLoaded => _session != null;
 
@@ -80,10 +74,11 @@ class ClassifierModel {
   // Lifecycle
   // ---------------------------------------------------------------------------
 
-  /// Load an ONNX model from raw [modelBytes].
+  /// Load an ONNX model from a file at [modelPath] on disk.
   ///
-  /// This is the primary loading method, suitable for models read from
-  /// Flutter's `rootBundle` or from any byte source.
+  /// `flutter_onnxruntime` only loads sessions from a file path (not raw
+  /// bytes); the audio model lives on disk via the asset pack service, so
+  /// this is the natural entry point.
   ///
   /// Tensor names default to BirdNET conventions but can be overridden to
   /// support any ONNX model:
@@ -93,76 +88,6 @@ class ClassifierModel {
   /// - [embeddingsName] — name of the embeddings output tensor, or `null` if
   ///   the model does not produce embeddings (default `"embeddings"`).
   ///
-  /// Initializes the ORT environment on first call.  May throw if the model
-  /// bytes are invalid.
-  Future<void> loadModel(
-    Uint8List modelBytes, {
-    String inputName = 'input',
-    String predictionsName = 'predictions',
-    String? embeddingsName = 'embeddings',
-  }) async {
-    _inputName = inputName;
-    _predictionsName = predictionsName;
-    _embeddingsName = embeddingsName;
-    if (!_envInitialized) {
-      OrtEnv.instance.init();
-      _envInitialized = true;
-    }
-
-    // Release previous session if reloading.
-    _session?.release();
-
-    final sessionOptions = OrtSessionOptions();
-    _session = OrtSession.fromBuffer(modelBytes, sessionOptions);
-    sessionOptions
-        .release(); // options are consumed by fromBuffer; release native memory
-
-    // Resolve output tensor indices by name so we don't rely on graph order.
-    _resolveOutputIndices();
-  }
-
-  /// Map configured output tensor names to their actual indices in the
-  /// session's output list.
-  ///
-  /// The ONNX graph may order outputs differently than expected (e.g.
-  /// embeddings before predictions).  Querying [OrtSession.outputNames]
-  /// lets us handle any ordering.
-  void _resolveOutputIndices() {
-    final session = _session;
-    if (session == null) return;
-
-    final names = session.outputNames;
-    debugPrint('[ClassifierModel] output tensor names: $names');
-
-    _predictionsIndex = names.indexOf(_predictionsName);
-    if (_predictionsIndex < 0) {
-      // Fallback: pick whichever output is NOT the embeddings output.
-      // If only one output exists, use index 0.
-      final embName = _embeddingsName;
-      if (embName != null && names.contains(embName)) {
-        _predictionsIndex = names.indexOf(embName) == 0 ? 1 : 0;
-      } else {
-        _predictionsIndex = 0;
-      }
-      debugPrint('[ClassifierModel] predictions name "$_predictionsName" not '
-          'found in outputs; falling back to index $_predictionsIndex');
-    }
-
-    final embName = _embeddingsName;
-    if (embName != null) {
-      _embeddingsIndex = names.indexOf(embName);
-    } else {
-      _embeddingsIndex = -1;
-    }
-
-    debugPrint('[ClassifierModel] resolved — predictions @ index '
-        '$_predictionsIndex, embeddings @ index $_embeddingsIndex');
-  }
-
-  /// Load an ONNX model from a file at [modelPath] on disk.
-  ///
-  /// Convenience wrapper that reads the file and delegates to [loadModel].
-  /// Tensor name parameters are forwarded — see [loadModel] for details.
   /// Throws [FileSystemException] if the file does not exist.
   Future<void> loadModelFromFile(
     String modelPath, {
@@ -174,13 +99,22 @@ class ClassifierModel {
     if (!modelFile.existsSync()) {
       throw FileSystemException('Model file not found', modelPath);
     }
-    final bytes = await modelFile.readAsBytes();
-    await loadModel(
-      bytes,
-      inputName: inputName,
-      predictionsName: predictionsName,
-      embeddingsName: embeddingsName,
-    );
+
+    _inputName = inputName;
+    _predictionsName = predictionsName;
+    _embeddingsName = embeddingsName;
+
+    // Release previous session if reloading.
+    final old = _session;
+    _session = null;
+    if (old != null) {
+      await old.close();
+    }
+
+    _session = await _ort.createSession(modelPath);
+
+    debugPrint('[ClassifierModel] loaded — inputs: ${_session!.inputNames} '
+        'outputs: ${_session!.outputNames}');
   }
 
   // ---------------------------------------------------------------------------
@@ -200,7 +134,7 @@ class ClassifierModel {
   }) async {
     final session = _session;
     if (session == null) {
-      throw StateError('Model not loaded. Call loadModel() first.');
+      throw StateError('Model not loaded. Call loadModelFromFile() first.');
     }
 
     // Prepare input: pad or truncate to exactly [windowSamples].
@@ -214,33 +148,29 @@ class ClassifierModel {
     // Remaining elements are already 0.0 (zero-padding).
 
     // Create input tensor: shape [1, windowSamples].
-    final inputTensor = OrtValueTensor.createTensorWithDataList(
-      input,
-      [1, windowSamples],
-    );
+    final inputTensor = await OrtValue.fromList(input, [1, windowSamples]);
 
-    final runOptions = OrtRunOptions();
-
+    Map<String, OrtValue>? outputs;
     try {
       // Run inference.
-      final outputs =
-          await session.runAsync(runOptions, {_inputName: inputTensor});
+      outputs = await session.run({_inputName: inputTensor});
 
-      // Extract predictions tensor using resolved index.
-      final predictionsRaw = outputs?[_predictionsIndex]?.value;
-      final predictions = _flatten(predictionsRaw);
+      // Extract predictions tensor by name.
+      final predTensor = outputs[_predictionsName];
+      if (predTensor == null) {
+        throw StateError(
+          'Predictions output "$_predictionsName" not found in model outputs '
+          '(${outputs.keys.toList()})',
+        );
+      }
+      final predictions = await _toDoubleList(predTensor);
 
       // Extract embeddings tensor if configured and available.
       List<double>? embeddings;
-      if (_embeddingsIndex >= 0 &&
-          outputs != null &&
-          _embeddingsIndex < outputs.length &&
-          outputs[_embeddingsIndex] != null) {
-        embeddings = _flatten(outputs[_embeddingsIndex]!.value);
+      final embName = _embeddingsName;
+      if (embName != null && outputs.containsKey(embName)) {
+        embeddings = await _toDoubleList(outputs[embName]!);
       }
-
-      // Release output tensors.
-      outputs?.forEach((e) => e?.release());
 
       return ModelOutput(
         predictions: predictions,
@@ -248,8 +178,12 @@ class ClassifierModel {
       );
     } finally {
       // Release native resources.
-      inputTensor.release();
-      runOptions.release();
+      await inputTensor.dispose();
+      if (outputs != null) {
+        for (final t in outputs.values) {
+          await t.dispose();
+        }
+      }
     }
   }
 
@@ -258,12 +192,11 @@ class ClassifierModel {
   // ---------------------------------------------------------------------------
 
   /// Release all native resources held by the ONNX session.
-  void dispose() {
-    _session?.release();
+  Future<void> dispose() async {
+    final s = _session;
     _session = null;
-    if (_envInitialized) {
-      OrtEnv.instance.release();
-      _envInitialized = false;
+    if (s != null) {
+      await s.close();
     }
   }
 
@@ -271,26 +204,14 @@ class ClassifierModel {
   // Helpers
   // ---------------------------------------------------------------------------
 
-  /// Flatten a nested list from ORT output into a single [List<double>].
-  ///
-  /// ORT may return `List<List<double>>` for batched outputs or `List<double>`
-  /// for single outputs.
-  static List<double> _flatten(dynamic value) {
-    if (value is List<List<double>>) {
-      // Batched output — take first batch.
-      return value.first;
-    }
-    if (value is List<double>) {
-      return value;
-    }
-    if (value is List) {
-      // Try to cast inner elements.
-      return value
-          .expand((e) => e is List ? e : [e])
-          .map((e) => (e as num).toDouble())
-          .toList();
-    }
-    throw ArgumentError('Unexpected ORT output type: ${value.runtimeType}');
+  /// Read a tensor's data as a flat `List<double>`. Handles whatever numeric
+  /// list type `flutter_onnxruntime` returns (`Float32List`, `List<num>`,
+  /// etc.).
+  static Future<List<double>> _toDoubleList(OrtValue tensor) async {
+    final raw = await tensor.asFlattenedList();
+    if (raw is List<double>) return raw;
+    if (raw is Float32List) return raw.toList();
+    return raw.map((e) => (e as num).toDouble()).toList(growable: false);
   }
 }
 
@@ -318,6 +239,7 @@ class ModelOutput {
 
   /// Feature embeddings (length = 1 280) for similarity/clustering.
   ///
-  /// May be `null` if the model output did not include embeddings.
+  /// Null if the model doesn't produce embeddings or [embeddingsName] was
+  /// not configured.
   final List<double>? embeddings;
 }

--- a/lib/features/inference/geo_model.dart
+++ b/lib/features/inference/geo_model.dart
@@ -42,7 +42,7 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
-import 'package:onnxruntime/onnxruntime.dart';
+import 'package:flutter_onnxruntime/flutter_onnxruntime.dart';
 
 /// A species entry from the geo-model's own labels file.
 class GeoSpecies {
@@ -88,10 +88,10 @@ class GeoModel {
   /// This runs 48 single-sample inferences (the model input is `[1,3]`)
   /// but collects results for every species in one pass — much more
   /// efficient than calling per-species.
-  Map<String, List<double>> predictAllWeeks({
+  Future<Map<String, List<double>>> predictAllWeeks({
     required double latitude,
     required double longitude,
-  }) {
+  }) async {
     if (!isReady) {
       throw StateError('GeoModel not ready. Call loadLabels() + loadModel().');
     }
@@ -103,7 +103,7 @@ class GeoModel {
     }
 
     for (int w = 1; w <= 48; w++) {
-      final scores = predict(
+      final scores = await predict(
         latitude: latitude,
         longitude: longitude,
         week: w,
@@ -120,9 +120,9 @@ class GeoModel {
   // State
   // ---------------------------------------------------------------------------
 
+  final OnnxRuntime _ort = OnnxRuntime();
   List<GeoSpecies> _labels = const [];
   OrtSession? _session;
-  bool _envInitialized = false;
 
   /// Configured tensor names (set from model config or defaults).
   String _inputName = 'input';
@@ -172,33 +172,31 @@ class GeoModel {
     _inputName = inputName;
     _outputName = outputName;
 
-    if (!_envInitialized) {
-      OrtEnv.instance.init();
-      _envInitialized = true;
-    }
-
-    _session?.release();
-
     final modelFile = File(modelPath);
     if (!modelFile.existsSync()) {
       throw FileSystemException('Geo-model file not found', modelPath);
     }
 
-    final bytes = await modelFile.readAsBytes();
-    final sessionOptions = OrtSessionOptions();
-    _session = OrtSession.fromBuffer(bytes, sessionOptions);
-    sessionOptions
-        .release(); // options are consumed by fromBuffer; release native memory
+    final old = _session;
+    _session = null;
+    if (old != null) {
+      await old.close();
+    }
+
+    _session = await _ort.createSession(modelPath);
 
     debugPrint('[GeoModel] model loaded from $modelPath');
     debugPrint('[GeoModel] input: $_inputName, output: $_outputName');
   }
 
   /// Release all resources.
-  void dispose() {
-    _session?.release();
+  Future<void> dispose() async {
+    final s = _session;
     _session = null;
     _labels = const [];
+    if (s != null) {
+      await s.close();
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -213,12 +211,13 @@ class GeoModel {
   /// [latitude]  in degrees (−90 to +90).
   /// [longitude] in degrees (−180 to +180).
   /// [week]      week of the year (1–48, 4 per month).
-  Map<String, double> predict({
+  Future<Map<String, double>> predict({
     required double latitude,
     required double longitude,
     required int week,
-  }) {
-    if (!isReady) {
+  }) async {
+    final session = _session;
+    if (session == null || _labels.isEmpty) {
       throw StateError('GeoModel not ready. Call loadLabels() + loadModel().');
     }
 
@@ -230,36 +229,23 @@ class GeoModel {
       longitude,
       week.toDouble(),
     ]);
-    final inputTensor = OrtValueTensor.createTensorWithDataList(
-      inputData,
-      [1, 3],
-    );
+    final inputTensor = await OrtValue.fromList(inputData, [1, 3]);
 
-    final runOptions = OrtRunOptions();
-
+    Map<String, OrtValue>? outputs;
     try {
-      // Run inference.
-      final inputs = {_inputName: inputTensor};
-      final outputs = _session!.run(runOptions, inputs);
+      outputs = await session.run({_inputName: inputTensor});
 
-      // Extract output probabilities.
-      final outputValue = outputs.firstOrNull;
-      if (outputValue == null) {
+      // Prefer the configured output name; fall back to first output.
+      final outputTensor = outputs[_outputName] ?? outputs.values.firstOrNull;
+      if (outputTensor == null) {
         throw StateError('Geo-model returned no output');
       }
-      final rawOutput = outputValue.value;
-
-      // The output is typically List<List<double>> for shape [1, N].
-      List<double> probabilities;
-      if (rawOutput is List<List<double>>) {
-        probabilities = rawOutput.first;
-      } else if (rawOutput is List) {
-        // Flatten if needed.
-        probabilities = rawOutput.cast<double>();
-      } else {
-        throw StateError(
-            'Unexpected geo-model output type: ${rawOutput.runtimeType}');
-      }
+      final raw = await outputTensor.asFlattenedList();
+      final probabilities = raw is List<double>
+          ? raw
+          : raw is Float32List
+              ? raw.toList()
+              : raw.map((e) => (e as num).toDouble()).toList(growable: false);
 
       // Build the result map.
       final scores = <String, double>{};
@@ -270,16 +256,14 @@ class GeoModel {
         scores[_labels[i].scientificName] = probabilities[i];
       }
 
-      // Release output tensors.
-      for (final o in outputs) {
-        o?.release();
-      }
-
       return scores;
     } finally {
-      // Release native resources.
-      inputTensor.release();
-      runOptions.release();
+      await inputTensor.dispose();
+      if (outputs != null) {
+        for (final t in outputs.values) {
+          await t.dispose();
+        }
+      }
     }
   }
 
@@ -287,13 +271,13 @@ class GeoModel {
   /// sorted by descending probability.
   ///
   /// Returns a list of [GeoSpeciesScore] tuples.
-  List<GeoSpeciesScore> expectedSpecies({
+  Future<List<GeoSpeciesScore>> expectedSpecies({
     required double latitude,
     required double longitude,
     required int week,
     double threshold = 0.03,
-  }) {
-    final scores = predict(
+  }) async {
+    final scores = await predict(
       latitude: latitude,
       longitude: longitude,
       week: week,
@@ -324,7 +308,7 @@ class GeoModel {
   }
 
   /// Return geo-model scores as a map (for use with [SpeciesFilter]).
-  Map<String, double> geoScoresForFilter({
+  Future<Map<String, double>> geoScoresForFilter({
     required double latitude,
     required double longitude,
     required int week,

--- a/lib/features/inference/inference_isolate.dart
+++ b/lib/features/inference/inference_isolate.dart
@@ -1,49 +1,26 @@
 // =============================================================================
-// Inference Isolate — Background ONNX inference via Dart Isolate
+// Inference Isolate — Thin in-process wrapper around InferenceService
 // =============================================================================
 //
-// The `onnxruntime` package uses dart:ffi, which means it CAN run in a Dart
-// isolate (unlike platform-channel-based plugins).  This class manages a
-// long-lived background isolate that:
+// Originally this class spawned a Dart [Isolate] to run ONNX inference off
+// the UI thread, because the `onnxruntime` package used dart:ffi (which is
+// isolate-friendly).
 //
-//   1. Loads the ONNX model once on start-up (using the supplied config).
-//   2. Accepts audio chunks via [SendPort] messages.
-//   3. Returns detection results back to the main isolate.
+// `flutter_onnxruntime` (the runtime we now ship) talks to the native ORT
+// session via platform channels and runs inference on a native background
+// thread queue, so the heavy work already happens off the UI thread.  The
+// remaining Dart-side post-processing (sigmoid, sort, top-K) takes
+// sub-millisecond on the 5,250-class label space and is safe to run on the
+// root isolate.
 //
-// ### Why an isolate?
-//
-// Even though the native ONNX Runtime engine runs inference off-thread, the
-// Dart-side pre-/post-processing (sigmoid over N values, sensitivity scaling,
-// sorting) can take several milliseconds.  Running this work in a separate
-// isolate prevents any chance of UI jank during rapid inference cycles.
-//
-// ### Message protocol
-//
-// Main → Worker:
-//   - [InferenceRequest] — audio samples + configuration
-//   - `null` — shutdown signal
-//
-// Worker → Main:
-//   - [InferenceResult] — list of [Detection]s
-//   - [InferenceError] — exception description
-//
-// ### Usage
-//
-// ```dart
-// final isolate = InferenceIsolate();
-// await isolate.start(
-//   modelFilePath: '/path/to/model.onnx',
-//   labelsCsv: '...',
-//   config: modelConfig,
-// );
-// final detections = await isolate.infer(audioSamples);
-// await isolate.stop();
-// ```
+// To minimize churn at the call sites this class now keeps the same public
+// API but delegates synchronously to a single [InferenceService] instance.
+// If post-processing latency becomes visible, we can wrap individual
+// operations in `compute()` later.
 // =============================================================================
 
 import 'dart:async';
 import 'dart:io';
-import 'dart:isolate';
 
 import 'package:flutter/foundation.dart';
 
@@ -51,40 +28,26 @@ import 'inference_service.dart';
 import 'model_config.dart';
 import 'models/detection.dart';
 
-// =============================================================================
-// Public API
-// =============================================================================
-
-/// Manages a background isolate for ONNX model inference.
+/// Runs ONNX inference for the audio classifier on the root isolate.
 ///
-/// Start the isolate with [start], send work with [infer], and clean up
-/// with [stop].
+/// The class keeps the historical "isolate" name to avoid a wide rename;
+/// see the file header for the rationale.
 class InferenceIsolate {
-  Isolate? _isolate;
-  SendPort? _sendPort;
-  final _responseCompleter = <int, Completer<List<Detection>>>{};
-  int _nextRequestId = 0;
-  StreamSubscription<dynamic>? _responseSubscription;
+  InferenceService? _service;
+  Future<void>? _pendingInfer; // serialize calls into the native session.
 
-  /// Whether the background isolate is running and ready.
-  bool get isRunning => _isolate != null && _sendPort != null;
+  /// Whether the underlying inference service is initialized and ready.
+  bool get isRunning => _service != null;
 
   // ---------------------------------------------------------------------------
   // Lifecycle
   // ---------------------------------------------------------------------------
 
-  /// Spawn the background isolate and load the model from a file.
+  /// Load the model from a file path and parse labels.
   ///
   /// [modelFilePath] — absolute path to the `.onnx` model file on disk.
   /// [labelsCsv] — full content of the labels file.
   /// [config] — model configuration (tensor names, label format, defaults).
-  ///
-  /// Loading from a file path instead of raw bytes avoids serializing ~259 MB
-  /// through the isolate port, which would triple peak memory usage.
-  ///
-  /// This method waits until the worker isolate has fully initialized the
-  /// ONNX session.  If initialization fails, the future completes with an
-  /// error.
   Future<void> start({
     required String modelFilePath,
     required String labelsCsv,
@@ -92,91 +55,43 @@ class InferenceIsolate {
   }) async {
     if (isRunning) return;
 
-    final receivePort = ReceivePort();
-
-    debugPrint('[InferenceIsolate] spawning worker …');
-    _isolate = await Isolate.spawn(
-      _workerEntryPoint,
-      _WorkerInit(
-        sendPort: receivePort.sendPort,
-        modelFilePath: modelFilePath,
-        labelsCsv: labelsCsv,
-        configJson: config.toJson(),
-      ),
-    );
-    debugPrint('[InferenceIsolate] worker spawned');
-
-    final sendPortCompleter = Completer<SendPort>();
-    final readyCompleter = Completer<void>();
-
-    _responseSubscription = receivePort.listen((message) {
-      if (message is SendPort) {
-        if (!sendPortCompleter.isCompleted) {
-          sendPortCompleter.complete(message);
-        }
-      } else if (message is _WorkerReady) {
-        if (!readyCompleter.isCompleted) {
-          readyCompleter.complete();
-        }
-      } else if (message is _WorkerInitError) {
-        if (!readyCompleter.isCompleted) {
-          readyCompleter.completeError(Exception(message.error));
-        }
-      } else if (message is _WorkerResponse) {
-        final c = _responseCompleter.remove(message.requestId);
-        if (c != null) {
-          if (message.error != null) {
-            c.completeError(Exception(message.error));
-          } else {
-            c.complete(message.detections);
-          }
-        }
-      }
-    });
-
-    try {
-      _sendPort = await sendPortCompleter.future.timeout(
-        const Duration(minutes: 2),
-      );
-      debugPrint('[InferenceIsolate] waiting for model init …');
-      await readyCompleter.future.timeout(const Duration(minutes: 2));
-      debugPrint('[InferenceIsolate] model ready');
-    } catch (_) {
-      receivePort.close();
-      await _responseSubscription?.cancel();
-      _responseSubscription = null;
-      _sendPort = null;
-      _isolate?.kill(priority: Isolate.immediate);
-      _isolate = null;
-      rethrow;
+    debugPrint('[InferenceIsolate] loading model from file: $modelFilePath');
+    if (!File(modelFilePath).existsSync()) {
+      throw FileSystemException('Model file not found', modelFilePath);
     }
+
+    final svc = InferenceService();
+    await svc.initialize(
+      modelFilePath: modelFilePath,
+      labelsCsv: labelsCsv,
+      config: config,
+    );
+    _service = svc;
+    debugPrint('[InferenceIsolate] model ready');
   }
 
-  /// Stop the background isolate and free resources.
+  /// Release the inference service and free native resources.
   Future<void> stop() async {
-    _sendPort?.send(null); // Shutdown signal.
-    _isolate?.kill(priority: Isolate.immediate);
-    _isolate = null;
-    _sendPort = null;
-    await _responseSubscription?.cancel();
-    _responseSubscription = null;
-
-    // Complete any pending futures with an error.
-    for (final c in _responseCompleter.values) {
-      c.completeError(StateError('Inference isolate stopped'));
+    final svc = _service;
+    _service = null;
+    if (svc != null) {
+      // Wait for any in-flight inference to settle before closing the session.
+      try {
+        await _pendingInfer;
+      } catch (_) {}
+      await svc.dispose();
     }
-    _responseCompleter.clear();
   }
 
   // ---------------------------------------------------------------------------
   // Inference
   // ---------------------------------------------------------------------------
 
-  /// Run inference on [audioSamples] in the background isolate.
+  /// Run inference on [audioSamples].
   ///
-  /// Parameters that are not supplied fall back to the active [ModelConfig]
-  /// defaults inside the worker.  Returns a list of [Detection] sorted by
-  /// descending confidence.
+  /// Calls are serialized so that overlapping requests never enter the
+  /// native session simultaneously (which would race on output tensor
+  /// disposal).
   Future<List<Detection>> infer(
     Float32List audioSamples, {
     int? windowSeconds,
@@ -184,233 +99,44 @@ class InferenceIsolate {
     double? confidenceThreshold,
     int? topK,
     bool useTemporalPooling = true,
-  }) {
-    if (!isRunning) {
-      throw StateError('Inference isolate not started. Call start() first.');
+  }) async {
+    final svc = _service;
+    if (svc == null) {
+      throw StateError('Inference service not started. Call start() first.');
     }
 
-    final requestId = _nextRequestId++;
-    final completer = Completer<List<Detection>>();
-    _responseCompleter[requestId] = completer;
-
-    _sendPort!.send(_WorkerRequest(
-      requestId: requestId,
-      audioSamples: audioSamples,
-      windowSeconds: windowSeconds,
-      sensitivity: sensitivity,
-      confidenceThreshold: confidenceThreshold,
-      topK: topK,
-      useTemporalPooling: useTemporalPooling,
-    ));
-
-    return completer.future;
-  }
-
-  /// Clear the temporal pooling buffer in the background isolate.
-  void resetPooling() {
-    _sendPort?.send(const _WorkerResetPooling());
-  }
-
-  /// Override the temporal-pooling window count in the worker. Pass `null`
-  /// to revert to the model-config default. Safe to call before the worker
-  /// has finished initializing — the message is dropped if the send port is
-  /// not yet wired up.
-  void setMaxPoolWindows(int? value) {
-    _sendPort?.send(_WorkerSetMaxPoolWindows(value));
-  }
-}
-
-// =============================================================================
-// Worker isolate entry point
-// =============================================================================
-
-/// Load the ONNX model in a **separate async scope** so that the ~259 MB
-/// `modelBytes` Uint8List becomes eligible for GC as soon as this function
-/// returns.  Dart's async state machine retains local variables that are live
-/// across `await` points as persistent fields — if this loading code lived
-/// directly inside the long-running [_workerEntryPoint], the model bytes would
-/// never be collected because that function's state machine stays alive for the
-/// lifetime of the isolate.
-Future<InferenceService> _loadModelInIsolate({
-  required String modelFilePath,
-  required String labelsCsv,
-  required ModelConfig config,
-}) async {
-  debugPrint('[InferenceIsolate] loading model from file: $modelFilePath');
-  final modelFile = File(modelFilePath);
-  final modelBytes = await modelFile.readAsBytes();
-  debugPrint('[InferenceIsolate] model bytes read: ${modelBytes.length}');
-
-  final svc = InferenceService();
-  await svc.initialize(
-    modelBytes: modelBytes,
-    labelsCsv: labelsCsv,
-    config: config,
-  );
-  debugPrint('[InferenceIsolate] model initialized');
-  // modelBytes (~259 MB) becomes unreachable when this frame is collected.
-  return svc;
-}
-
-/// Top-level function that runs inside the background isolate.
-///
-/// Receives an [_WorkerInit] with the model path and labels CSV, initializes
-/// the [InferenceService], then processes [_WorkerRequest] messages in a loop.
-Future<void> _workerEntryPoint(_WorkerInit init) async {
-  final receivePort = ReceivePort();
-
-  // Send our SendPort back so the main isolate can talk to us.
-  init.sendPort.send(receivePort.sendPort);
-
-  final config = ModelConfig.fromJson(
-    Map<String, dynamic>.from(init.configJson),
-  );
-
-  // Initialize the model in a separate async function so the large
-  // modelBytes buffer is not retained by this function's async state machine.
-  final InferenceService service;
-  try {
-    service = await _loadModelInIsolate(
-      modelFilePath: init.modelFilePath,
-      labelsCsv: init.labelsCsv,
-      config: config,
-    );
-    init.sendPort.send(const _WorkerReady());
-  } catch (e) {
-    debugPrint('[InferenceIsolate] init error: $e');
-    init.sendPort.send(_WorkerInitError(e.toString()));
-    receivePort.close();
-    return;
-  }
-
-  // Process inference requests.
-  await for (final message in receivePort) {
-    if (message == null) {
-      // Shutdown signal.
-      service.dispose();
-      receivePort.close();
-      break;
-    }
-
-    if (message is _WorkerResetPooling) {
-      service.resetPooling();
-      continue;
-    }
-
-    if (message is _WorkerSetMaxPoolWindows) {
-      service.setMaxPoolWindows(message.value);
-      continue;
-    }
-
-    if (message is _WorkerRequest) {
-      debugPrint('[InferenceIsolate] processing request #${message.requestId} '
-          '(${message.audioSamples.length} samples)');
-      try {
-        final detections = await service.infer(
-          message.audioSamples,
-          windowSeconds: message.windowSeconds,
-          sensitivity: message.sensitivity,
-          confidenceThreshold: message.confidenceThreshold,
-          topK: message.topK,
-          useTemporalPooling: message.useTemporalPooling,
-        );
-        debugPrint('[InferenceIsolate] request #${message.requestId} → '
-            '${detections.length} detections');
-        init.sendPort.send(_WorkerResponse(
-          requestId: message.requestId,
-          detections: detections,
-        ));
-      } catch (e, st) {
-        debugPrint('[InferenceIsolate] request #${message.requestId} ERROR: '
-            '$e\n$st');
-        init.sendPort.send(_WorkerResponse(
-          requestId: message.requestId,
-          detections: const [],
-          error: e.toString(),
-        ));
+    // Serialize concurrent inference calls.
+    final previous = _pendingInfer;
+    final completer = Completer<void>();
+    _pendingInfer = completer.future;
+    try {
+      if (previous != null) {
+        try {
+          await previous;
+        } catch (_) {}
       }
+      return await svc.infer(
+        audioSamples,
+        windowSeconds: windowSeconds,
+        sensitivity: sensitivity,
+        confidenceThreshold: confidenceThreshold,
+        topK: topK,
+        useTemporalPooling: useTemporalPooling,
+      );
+    } finally {
+      completer.complete();
     }
   }
-}
 
-// =============================================================================
-// Message types (internal, not exported)
-// =============================================================================
+  /// Clear the temporal pooling buffer.
+  void resetPooling() {
+    _service?.resetPooling();
+  }
 
-/// Initialization data sent to the worker isolate.
-class _WorkerInit {
-  const _WorkerInit({
-    required this.sendPort,
-    required this.modelFilePath,
-    required this.labelsCsv,
-    required this.configJson,
-  });
-  final SendPort sendPort;
-
-  /// Absolute path to the `.onnx` model file on the device filesystem.
-  ///
-  /// The isolate reads the file directly, avoiding the need to serialize
-  /// hundreds of megabytes of model bytes through the isolate port.
-  final String modelFilePath;
-  final String labelsCsv;
-
-  /// Serialized [ModelConfig] as a JSON map.
-  ///
-  /// We pass a plain map instead of [ModelConfig] because [Isolate.spawn]
-  /// can only send primitive/transferable types.
-  final Map<String, dynamic> configJson;
-}
-
-/// Inference request sent from main → worker.
-class _WorkerRequest {
-  const _WorkerRequest({
-    required this.requestId,
-    required this.audioSamples,
-    this.windowSeconds,
-    this.sensitivity,
-    this.confidenceThreshold,
-    this.topK,
-    required this.useTemporalPooling,
-  });
-  final int requestId;
-  final Float32List audioSamples;
-  final int? windowSeconds;
-  final double? sensitivity;
-  final double? confidenceThreshold;
-  final int? topK;
-  final bool useTemporalPooling;
-}
-
-/// Response sent from worker → main.
-class _WorkerResponse {
-  const _WorkerResponse({
-    required this.requestId,
-    required this.detections,
-    this.error,
-  });
-  final int requestId;
-  final List<Detection> detections;
-  final String? error;
-}
-
-/// Signal to reset the temporal pooling buffer.
-class _WorkerResetPooling {
-  const _WorkerResetPooling();
-}
-
-/// Override the rolling temporal-pooling window count.
-class _WorkerSetMaxPoolWindows {
-  const _WorkerSetMaxPoolWindows(this.value);
-  final int? value;
-}
-
-/// Signal that the worker has finished initializing the model.
-class _WorkerReady {
-  const _WorkerReady();
-}
-
-/// Signal that the worker failed to initialize the model.
-class _WorkerInitError {
-  const _WorkerInitError(this.error);
-  final String error;
+  /// Override the temporal-pooling window count. Pass `null` to revert to
+  /// the model-config default. Safe to call before [start] has completed —
+  /// the call is dropped if the service is not yet ready.
+  void setMaxPoolWindows(int? value) {
+    _service?.setMaxPoolWindows(value);
+  }
 }

--- a/lib/features/inference/inference_service.dart
+++ b/lib/features/inference/inference_service.dart
@@ -23,7 +23,7 @@
 // ```dart
 // final svc = InferenceService();
 // await svc.initialize(
-//   modelBytes: bytes,
+//   modelFilePath: '/path/to/model.onnx',
 //   labelsCsv: csvText,
 //   config: modelConfig,
 // );
@@ -114,19 +114,19 @@ class InferenceService {
 
   /// Load the ONNX model and parse species labels.
   ///
-  /// [modelBytes] — raw bytes of the `.onnx` model file.
+  /// [modelFilePath] — absolute path to the `.onnx` model file on disk.
   /// [labelsCsv] — full text content of the labels file.
   /// [config] — model configuration describing tensor names, label format,
   ///   and inference defaults.
   Future<void> initialize({
-    required Uint8List modelBytes,
+    required String modelFilePath,
     required String labelsCsv,
     required ModelConfig config,
   }) async {
     _config = config;
     _labels = LabelParser.parse(labelsCsv, config: config.labels);
-    await _model.loadModel(
-      modelBytes,
+    await _model.loadModelFromFile(
+      modelFilePath,
       inputName: config.onnx.inputName,
       predictionsName: config.onnx.predictionsName,
       embeddingsName: config.onnx.embeddingsName,
@@ -134,8 +134,8 @@ class InferenceService {
   }
 
   /// Release all resources (ONNX session, native memory).
-  void dispose() {
-    _model.dispose();
+  Future<void> dispose() async {
+    await _model.dispose();
     _labels = const [];
     _config = null;
     _recentScores.clear();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: birdnet_live
 description: "Real-time bird species identification using on-device ONNX inference"
 publish_to: 'none'
-version: 0.8.3+95
+version: 0.9.0+96
 
 environment:
-  sdk: ^3.6.2
+  sdk: ^3.7.0
 
 dependencies:
   flutter:
@@ -27,7 +27,7 @@ dependencies:
   fftea: ^1.2.0
 
   # Inference
-  onnxruntime: ^1.4.1
+  flutter_onnxruntime: ^1.7.0
 
   # UI & UX
   url_launcher: ^6.3.1


### PR DESCRIPTION
Update the ONNX runtime to `flutter_onnxruntime 1.7` for 16 KB page-size compliance and simplify the inference architecture. Refactor Gradle configuration and integration tests for improved clarity. Upgrade Flutter SDK to 3.7.0.