### PR TITLE
Improve external link handling and invert grayscale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.6] - 2026-05-02
+
+### Changed
+
+- **Grayscale spectrogram colormap inverted: white now means quiet, black means loud.** Matches Audacity, Raven, Sonic Visualiser, matplotlib's `gray_r`, and printed sonograms in field guides. Quiet background reads as paper-white instead of a black wall, so the spectrogram is legible on light themes and exports cleanly to print (#33).
+
 ## [0.9.5] - 2026-05-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.5] - 2026-05-02
+
+### Fixed
+
+- **External link chips (eBird, iNaturalist, Wikipedia, About-screen links) now open reliably on Android 11+** (#34). Under Android 11+ package-visibility rules, `canLaunchUrl` returns `false` for an `https`/`mailto` intent unless the app's manifest declares an `<intent>` query for `ACTION_VIEW` with that scheme. The previous `if (await canLaunchUrl(uri)) launchUrl(uri)` pattern silently no-op'd on devices where Android hid the user's browser from the visibility query (reported on a Pixel 9 Pro running Android 16). The manifest now declares `ACTION_VIEW` queries for `http`, `https`, and `mailto`, and the call sites use a new `openExternalUrl` helper that drops the `canLaunchUrl` probe entirely and falls back to copying the URL to the clipboard with a SnackBar message if launching genuinely fails (no browser installed at all).
+
 ## [0.9.4] - 2026-05-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.4] - 2026-05-02
+
+### Fixed
+
+- **Wikipedia link now always appears on species cards.** Previously the Wikipedia chip in the species info overlay was hidden when the bundled `taxonomy.csv` had no entry for the user's locale, leaving non-English users without a link even though an English page almost always exists. The chip now follows a three-step fallback: locale-specific bundled URL → English bundled URL → constructed `https://en.wikipedia.org/wiki/<Genus_species>` from the scientific name. The chip is now always visible whenever species details load (part of #33).
+
 ## [0.9.3] - 2026-05-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
   <img src="https://img.shields.io/badge/flutter-%3E%3D3.0-blue.svg" alt="Flutter">
   <img src="https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Windows-green.svg" alt="Platforms">
-  <img src="https://img.shields.io/badge/version-0.9.4-orange.svg" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.9.5-orange.svg" alt="Version">
   <img src="https://img.shields.io/badge/species-5%2C250-brightgreen.svg" alt="Species: 5,250">
 </p>
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
   <img src="https://img.shields.io/badge/flutter-%3E%3D3.0-blue.svg" alt="Flutter">
   <img src="https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Windows-green.svg" alt="Platforms">
-  <img src="https://img.shields.io/badge/version-0.9.3-orange.svg" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.9.4-orange.svg" alt="Version">
   <img src="https://img.shields.io/badge/species-5%2C250-brightgreen.svg" alt="Species: 5,250">
 </p>
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
   <img src="https://img.shields.io/badge/flutter-%3E%3D3.0-blue.svg" alt="Flutter">
   <img src="https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Windows-green.svg" alt="Platforms">
-  <img src="https://img.shields.io/badge/version-0.9.5-orange.svg" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.9.6-orange.svg" alt="Version">
   <img src="https://img.shields.io/badge/species-5%2C250-brightgreen.svg" alt="Species: 5,250">
 </p>
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -63,5 +63,22 @@
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
         </intent>
+        <!-- Required so url_launcher's canLaunchUrl / launchUrl can resolve
+             external https/http links (e.g. species Wikipedia/eBird/iNaturalist
+             chips, About-screen links). Without these <intent> entries Android
+             11+ package visibility hides browsers from us and url_launcher
+             reports "no activity found", even when Chrome/Firefox are installed. -->
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
+            <data android:scheme="https"/>
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
+            <data android:scheme="http"/>
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
+            <data android:scheme="mailto"/>
+        </intent>
     </queries>
 </manifest>

--- a/lib/features/about/about_screen.dart
+++ b/lib/features/about/about_screen.dart
@@ -23,192 +23,198 @@ class AboutScreen extends ConsumerWidget {
     final packageInfo = ref.watch(packageInfoProvider);
 
     return Scaffold(
-      appBar: AppBar(
-        title: Text(l10n.about),
-      ),
+      appBar: AppBar(title: Text(l10n.about)),
       body: ContentWidthConstraint(
-          child: ListView(
-        padding: const EdgeInsets.all(16),
-        children: [
-          // App icon and title
-          Center(
-            child: Column(
-              children: [
-                ClipOval(
-                  child: Image.asset(
-                    'assets/images/app-icon.png',
-                    width: 80,
-                    height: 80,
-                    fit: BoxFit.cover,
-                  ),
-                ),
-                const SizedBox(height: 12),
-                Text(
-                  AppConstants.appName,
-                  style: theme.textTheme.headlineSmall?.copyWith(
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                const SizedBox(height: 4),
-                packageInfo.when(
-                  data: (info) => Text(
-                    l10n.aboutVersionLabel(info.version, info.buildNumber),
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      color: theme.colorScheme.onSurface.withAlpha(153),
-                    ),
-                  ),
-                  loading: () => const SizedBox.shrink(),
-                  error: (_, __) => const SizedBox.shrink(),
-                ),
-              ],
-            ),
-          ),
-
-          const SizedBox(height: 32),
-
-          // Combined model info — audio model + geo-model in one card.
-          // Shows the model display name for each plus the shared species
-          // count once at the bottom (both ship with the same 5,250-species
-          // intersection, so repeating it on two cards was redundant).
-          Card(
-            child: Padding(
-              padding: const EdgeInsets.all(16),
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            // App icon and title
+            Center(
               child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    l10n.aboutModelVersion,
-                    style: theme.textTheme.titleSmall?.copyWith(
-                      color: theme.colorScheme.primary,
-                      fontWeight: FontWeight.w600,
+                  ClipOval(
+                    child: Image.asset(
+                      'assets/images/app-icon.png',
+                      width: 80,
+                      height: 80,
+                      fit: BoxFit.cover,
                     ),
                   ),
-                  const SizedBox(height: 8),
-                  Text(l10n.aboutModelName),
                   const SizedBox(height: 12),
                   Text(
-                    l10n.aboutGeoModel,
-                    style: theme.textTheme.titleSmall?.copyWith(
-                      color: theme.colorScheme.primary,
-                      fontWeight: FontWeight.w600,
+                    AppConstants.appName,
+                    style: theme.textTheme.headlineSmall?.copyWith(
+                      fontWeight: FontWeight.bold,
                     ),
                   ),
-                  const SizedBox(height: 8),
-                  Text(l10n.aboutGeoModelName),
-                  const SizedBox(height: 12),
-                  Text(
-                    l10n.aboutSpeciesCount(AppConstants.speciesCount),
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: theme.colorScheme.onSurface.withAlpha(153),
-                    ),
+                  const SizedBox(height: 4),
+                  packageInfo.when(
+                    data:
+                        (info) => Text(
+                          l10n.aboutVersionLabel(
+                            info.version,
+                            info.buildNumber,
+                          ),
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: theme.colorScheme.onSurface.withAlpha(153),
+                          ),
+                        ),
+                    loading: () => const SizedBox.shrink(),
+                    error: (_, __) => const SizedBox.shrink(),
                   ),
                 ],
               ),
             ),
-          ),
 
-          const SizedBox(height: 16),
+            const SizedBox(height: 32),
 
-          // Credits
-          Card(
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    l10n.aboutCredits,
-                    style: theme.textTheme.titleSmall?.copyWith(
-                      color: theme.colorScheme.primary,
-                      fontWeight: FontWeight.w600,
+            // Combined model info — audio model + geo-model in one card.
+            // Shows the model display name for each plus the shared species
+            // count once at the bottom (both ship with the same 5,250-species
+            // intersection, so repeating it on two cards was redundant).
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      l10n.aboutModelVersion,
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        color: theme.colorScheme.primary,
+                        fontWeight: FontWeight.w600,
+                      ),
                     ),
-                  ),
-                  const SizedBox(height: 8),
-                  Text(l10n.aboutCreditsDescription),
-                ],
-              ),
-            ),
-          ),
-
-          const SizedBox(height: 12),
-
-          // Funding
-          Card(
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    l10n.aboutFunding,
-                    style: theme.textTheme.titleSmall?.copyWith(
-                      color: theme.colorScheme.primary,
-                      fontWeight: FontWeight.w600,
+                    const SizedBox(height: 8),
+                    Text(l10n.aboutModelName),
+                    const SizedBox(height: 12),
+                    Text(
+                      l10n.aboutGeoModel,
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        color: theme.colorScheme.primary,
+                        fontWeight: FontWeight.w600,
+                      ),
                     ),
+                    const SizedBox(height: 8),
+                    Text(l10n.aboutGeoModelName),
+                    const SizedBox(height: 12),
+                    Text(
+                      l10n.aboutSpeciesCount(AppConstants.speciesCount),
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurface.withAlpha(153),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+
+            const SizedBox(height: 16),
+
+            // Credits
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      l10n.aboutCredits,
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        color: theme.colorScheme.primary,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(l10n.aboutCreditsDescription),
+                  ],
+                ),
+              ),
+            ),
+
+            const SizedBox(height: 12),
+
+            // Funding
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      l10n.aboutFunding,
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        color: theme.colorScheme.primary,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(l10n.aboutFundingDescription),
+                  ],
+                ),
+              ),
+            ),
+
+            const SizedBox(height: 24),
+
+            // Links
+            ListTile(
+              leading: ColorFiltered(
+                colorFilter: ColorFilter.mode(
+                  theme.colorScheme.onSurfaceVariant,
+                  BlendMode.srcIn,
+                ),
+                child: Image.asset(
+                  'assets/images/icon-birdnet.png',
+                  width: 24,
+                  height: 24,
+                ),
+              ),
+              title: Text(l10n.aboutWebsite),
+              trailing: const Icon(Icons.open_in_new),
+              onTap: () => openExternalUrl(context, AppConstants.birdnetUrl),
+            ),
+            ListTile(
+              leading: const Icon(Icons.code),
+              title: Text(l10n.aboutGitHub),
+              trailing: const Icon(Icons.open_in_new),
+              onTap: () => openExternalUrl(context, AppConstants.githubUrl),
+            ),
+            ListTile(
+              leading: const Icon(Icons.privacy_tip_outlined),
+              title: Text(l10n.aboutPrivacyPolicy),
+              trailing: const Icon(Icons.open_in_new),
+              onTap:
+                  () => openExternalUrl(
+                    context,
+                    '${AppConstants.docsUrl}${Localizations.localeOf(context).languageCode == 'en' ? '' : '/${Localizations.localeOf(context).languageCode}'}/privacy/',
                   ),
-                  const SizedBox(height: 8),
-                  Text(l10n.aboutFundingDescription),
-                ],
-              ),
             ),
-          ),
+            ListTile(
+              leading: const Icon(Icons.gavel),
+              title: Text(l10n.aboutTermsOfUse),
+              trailing: const Icon(Icons.open_in_new),
+              onTap:
+                  () => openExternalUrl(
+                    context,
+                    '${AppConstants.docsUrl}${Localizations.localeOf(context).languageCode == 'en' ? '' : '/${Localizations.localeOf(context).languageCode}'}/terms/',
+                  ),
+            ),
+            ListTile(
+              leading: const Icon(Icons.menu_book_outlined),
+              title: Text(l10n.aboutUserGuide),
+              trailing: const Icon(Icons.open_in_new),
+              onTap:
+                  () => openExternalUrl(
+                    context,
+                    '${AppConstants.docsUrl}${Localizations.localeOf(context).languageCode == 'en' ? '' : '/${Localizations.localeOf(context).languageCode}'}/user/',
+                  ),
+            ),
 
-          const SizedBox(height: 24),
-
-          // Links
-          ListTile(
-            leading: ColorFiltered(
-              colorFilter: ColorFilter.mode(
-                theme.colorScheme.onSurfaceVariant,
-                BlendMode.srcIn,
-              ),
-              child: Image.asset(
-                'assets/images/icon-birdnet.png',
-                width: 24,
-                height: 24,
-              ),
-            ),
-            title: Text(l10n.aboutWebsite),
-            trailing: const Icon(Icons.open_in_new),
-            onTap: () => openExternalUrl(context, AppConstants.birdnetUrl),
-          ),
-          ListTile(
-            leading: const Icon(Icons.code),
-            title: Text(l10n.aboutGitHub),
-            trailing: const Icon(Icons.open_in_new),
-            onTap: () => openExternalUrl(context, AppConstants.githubUrl),
-          ),
-          ListTile(
-            leading: const Icon(Icons.privacy_tip_outlined),
-            title: Text(l10n.aboutPrivacyPolicy),
-            trailing: const Icon(Icons.open_in_new),
-            onTap: () => openExternalUrl(
-              context,
-              '${AppConstants.docsUrl}${Localizations.localeOf(context).languageCode == 'en' ? '' : '/${Localizations.localeOf(context).languageCode}'}/privacy/',
-            ),
-          ),
-          ListTile(
-            leading: const Icon(Icons.gavel),
-            title: Text(l10n.aboutTermsOfUse),
-            trailing: const Icon(Icons.open_in_new),
-            onTap: () => openExternalUrl(
-              context,
-              '${AppConstants.docsUrl}${Localizations.localeOf(context).languageCode == 'en' ? '' : '/${Localizations.localeOf(context).languageCode}'}/terms/',
-            ),
-          ),
-          ListTile(
-            leading: const Icon(Icons.menu_book_outlined),
-            title: Text(l10n.aboutUserGuide),
-            trailing: const Icon(Icons.open_in_new),
-            onTap: () => openExternalUrl(
-              context,
-              '${AppConstants.docsUrl}${Localizations.localeOf(context).languageCode == 'en' ? '' : '/${Localizations.localeOf(context).languageCode}'}/user/',
-            ),
-          ),
-
-          const SizedBox(height: 32),
-        ],
-      )),
+            const SizedBox(height: 32),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/features/about/about_screen.dart
+++ b/lib/features/about/about_screen.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:birdnet_live/l10n/app_localizations.dart';
 import 'package:package_info_plus/package_info_plus.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import '../../core/constants/app_constants.dart';
+import '../../shared/services/link_launcher.dart';
 import '../../shared/widgets/content_width_constraint.dart';
 
 /// Provider for app package info.
@@ -170,46 +170,45 @@ class AboutScreen extends ConsumerWidget {
             ),
             title: Text(l10n.aboutWebsite),
             trailing: const Icon(Icons.open_in_new),
-            onTap: () => _launchUrl(AppConstants.birdnetUrl),
+            onTap: () => openExternalUrl(context, AppConstants.birdnetUrl),
           ),
           ListTile(
             leading: const Icon(Icons.code),
             title: Text(l10n.aboutGitHub),
             trailing: const Icon(Icons.open_in_new),
-            onTap: () => _launchUrl(AppConstants.githubUrl),
+            onTap: () => openExternalUrl(context, AppConstants.githubUrl),
           ),
           ListTile(
             leading: const Icon(Icons.privacy_tip_outlined),
             title: Text(l10n.aboutPrivacyPolicy),
             trailing: const Icon(Icons.open_in_new),
-            onTap: () => _launchUrl(
-                '${AppConstants.docsUrl}${Localizations.localeOf(context).languageCode == 'en' ? '' : '/${Localizations.localeOf(context).languageCode}'}/privacy/'),
+            onTap: () => openExternalUrl(
+              context,
+              '${AppConstants.docsUrl}${Localizations.localeOf(context).languageCode == 'en' ? '' : '/${Localizations.localeOf(context).languageCode}'}/privacy/',
+            ),
           ),
           ListTile(
             leading: const Icon(Icons.gavel),
             title: Text(l10n.aboutTermsOfUse),
             trailing: const Icon(Icons.open_in_new),
-            onTap: () => _launchUrl(
-                '${AppConstants.docsUrl}${Localizations.localeOf(context).languageCode == 'en' ? '' : '/${Localizations.localeOf(context).languageCode}'}/terms/'),
+            onTap: () => openExternalUrl(
+              context,
+              '${AppConstants.docsUrl}${Localizations.localeOf(context).languageCode == 'en' ? '' : '/${Localizations.localeOf(context).languageCode}'}/terms/',
+            ),
           ),
           ListTile(
             leading: const Icon(Icons.menu_book_outlined),
             title: Text(l10n.aboutUserGuide),
             trailing: const Icon(Icons.open_in_new),
-            onTap: () => _launchUrl(
-                '${AppConstants.docsUrl}${Localizations.localeOf(context).languageCode == 'en' ? '' : '/${Localizations.localeOf(context).languageCode}'}/user/'),
+            onTap: () => openExternalUrl(
+              context,
+              '${AppConstants.docsUrl}${Localizations.localeOf(context).languageCode == 'en' ? '' : '/${Localizations.localeOf(context).languageCode}'}/user/',
+            ),
           ),
 
           const SizedBox(height: 32),
         ],
       )),
     );
-  }
-
-  Future<void> _launchUrl(String url) async {
-    final uri = Uri.parse(url);
-    if (await canLaunchUrl(uri)) {
-      await launchUrl(uri, mode: LaunchMode.externalApplication);
-    }
   }
 }

--- a/lib/features/explore/explore_screen.dart
+++ b/lib/features/explore/explore_screen.dart
@@ -21,11 +21,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:birdnet_live/l10n/app_localizations.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import '../../core/services/reverse_geocoding_service.dart';
 import '../../shared/models/taxonomy_species.dart';
 import '../../shared/providers/settings_providers.dart';
+import '../../shared/services/link_launcher.dart';
 import '../../shared/widgets/app_help_bottom_sheet.dart';
 import '../../shared/widgets/content_width_constraint.dart';
 import '../../shared/widgets/empty_view.dart';
@@ -921,12 +921,10 @@ class _ExploreHelpLink extends StatelessWidget {
     final theme = Theme.of(context);
 
     return InkWell(
-      onTap: () async {
-        final uri = Uri.parse('https://birdnet-team.github.io/geomodel/');
-        if (await canLaunchUrl(uri)) {
-          await launchUrl(uri, mode: LaunchMode.externalApplication);
-        }
-      },
+      onTap: () => openExternalUrl(
+        context,
+        'https://birdnet-team.github.io/geomodel/',
+      ),
       child: Row(
         children: [
           Icon(

--- a/lib/features/explore/explore_screen.dart
+++ b/lib/features/explore/explore_screen.dart
@@ -50,18 +50,18 @@ enum _TaxonGroup {
 
   /// Matches the `taxon_group` column in the bundled taxonomy CSV.
   String get csvValue => switch (this) {
-        _TaxonGroup.aves => 'Aves',
-        _TaxonGroup.mammalia => 'Mammalia',
-        _TaxonGroup.amphibia => 'Amphibia',
-        _TaxonGroup.insecta => 'Insecta',
-      };
+    _TaxonGroup.aves => 'Aves',
+    _TaxonGroup.mammalia => 'Mammalia',
+    _TaxonGroup.amphibia => 'Amphibia',
+    _TaxonGroup.insecta => 'Insecta',
+  };
 
   String label(AppLocalizations l10n) => switch (this) {
-        _TaxonGroup.aves => l10n.exploreFilterBirds,
-        _TaxonGroup.mammalia => l10n.exploreFilterMammals,
-        _TaxonGroup.amphibia => l10n.exploreFilterAmphibians,
-        _TaxonGroup.insecta => l10n.exploreFilterInsects,
-      };
+    _TaxonGroup.aves => l10n.exploreFilterBirds,
+    _TaxonGroup.mammalia => l10n.exploreFilterMammals,
+    _TaxonGroup.amphibia => l10n.exploreFilterAmphibians,
+    _TaxonGroup.insecta => l10n.exploreFilterInsects,
+  };
 }
 
 /// Sort modes for the explore list.
@@ -167,21 +167,22 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen> {
                       ),
                       const SizedBox(height: 16),
                       _ExploreSheetHeader(
-                          label: l10n.exploreDetectionFilterTooltip),
+                        label: l10n.exploreDetectionFilterTooltip,
+                      ),
                       _ExploreSheetChoiceChips<_DetectionFilter>(
                         current: _detectionFilter,
                         options: [
                           (
                             _DetectionFilter.all,
-                            l10n.exploreDetectionFilterAll
+                            l10n.exploreDetectionFilterAll,
                           ),
                           (
                             _DetectionFilter.detected,
-                            l10n.exploreDetectionFilterDetected
+                            l10n.exploreDetectionFilterDetected,
                           ),
                           (
                             _DetectionFilter.undetected,
-                            l10n.exploreDetectionFilterUndetected
+                            l10n.exploreDetectionFilterUndetected,
                           ),
                         ],
                         onSelected: (m) => update(() => _detectionFilter = m),
@@ -204,12 +205,13 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen> {
                           if (!_groups.add(g)) _groups.remove(g);
                           update(() {});
                         },
-                        onClear: _groups.isEmpty
-                            ? null
-                            : () {
-                                _groups.clear();
-                                update(() {});
-                              },
+                        onClear:
+                            _groups.isEmpty
+                                ? null
+                                : () {
+                                  _groups.clear();
+                                  update(() {});
+                                },
                         clearLabel: l10n.exploreFilterAll,
                       ),
                     ],
@@ -275,9 +277,10 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen> {
           // Search toggle.
           IconButton(
             icon: Icon(_searchVisible ? Icons.close : Icons.search),
-            tooltip: _searchVisible
-                ? l10n.tooltipClearSearch
-                : l10n.exploreSearchTooltip,
+            tooltip:
+                _searchVisible
+                    ? l10n.tooltipClearSearch
+                    : l10n.exploreSearchTooltip,
             onPressed: _toggleSearch,
           ),
           // Help (swapped with refresh — refresh now lives in the
@@ -293,12 +296,13 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen> {
       body: ContentWidthConstraint(
         child: speciesAsync.when(
           loading: () => const LoadingView(),
-          error: (error, _) => ErrorView(
-            title: l10n.statusError,
-            message: error.toString(),
-            onRetry: _refresh,
-            retryLabel: l10n.retry,
-          ),
+          error:
+              (error, _) => ErrorView(
+                title: l10n.statusError,
+                message: error.toString(),
+                onRetry: _refresh,
+                retryLabel: l10n.retry,
+              ),
           data: (localSpecies) {
             return Column(
               children: [
@@ -314,59 +318,68 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen> {
                   duration: const Duration(milliseconds: 180),
                   curve: Curves.easeInOut,
                   alignment: Alignment.topCenter,
-                  child: _searchVisible
-                      ? Padding(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 12, vertical: 8),
-                          child: TextField(
-                            controller: _searchController,
-                            focusNode: _searchFocusNode,
-                            onChanged: _onQueryChanged,
-                            textInputAction: TextInputAction.search,
-                            decoration: InputDecoration(
-                              hintText: l10n.exploreSearchHint,
-                              prefixIcon: const Icon(Icons.search, size: 20),
-                              isDense: true,
-                              contentPadding: const EdgeInsets.symmetric(
-                                horizontal: 12,
-                                vertical: 12,
-                              ),
-                              border: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(12),
-                              ),
-                              suffixIcon: _query.isNotEmpty
-                                  ? IconButton(
-                                      icon: const Icon(Icons.clear, size: 20),
-                                      tooltip: l10n.tooltipClearSearch,
-                                      onPressed: () {
-                                        _searchController.clear();
-                                        _onQueryChanged('');
-                                      },
-                                    )
-                                  : null,
+                  child:
+                      _searchVisible
+                          ? Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 12,
+                              vertical: 8,
                             ),
-                          ),
-                        )
-                      : const SizedBox(width: double.infinity, height: 0),
+                            child: TextField(
+                              controller: _searchController,
+                              focusNode: _searchFocusNode,
+                              onChanged: _onQueryChanged,
+                              textInputAction: TextInputAction.search,
+                              decoration: InputDecoration(
+                                hintText: l10n.exploreSearchHint,
+                                prefixIcon: const Icon(Icons.search, size: 20),
+                                isDense: true,
+                                contentPadding: const EdgeInsets.symmetric(
+                                  horizontal: 12,
+                                  vertical: 12,
+                                ),
+                                border: OutlineInputBorder(
+                                  borderRadius: BorderRadius.circular(12),
+                                ),
+                                suffixIcon:
+                                    _query.isNotEmpty
+                                        ? IconButton(
+                                          icon: const Icon(
+                                            Icons.clear,
+                                            size: 20,
+                                          ),
+                                          tooltip: l10n.tooltipClearSearch,
+                                          onPressed: () {
+                                            _searchController.clear();
+                                            _onQueryChanged('');
+                                          },
+                                        )
+                                        : null,
+                              ),
+                            ),
+                          )
+                          : const SizedBox(width: double.infinity, height: 0),
                 ),
 
                 // ── Body: either geo list or search results ──
                 Expanded(
-                  child: _query.isEmpty
-                      ? _GeoList(
-                          species: localSpecies,
-                          groups: _groups,
-                          sortMode: _sortMode,
-                          detectionFilter: _detectionFilter,
-                          locationAvailable: locationAsync.valueOrNull != null,
-                        )
-                      : _SearchResults(
-                          query: _query,
-                          groups: _groups,
-                          sortMode: _sortMode,
-                          detectionFilter: _detectionFilter,
-                          localSpecies: localSpecies,
-                        ),
+                  child:
+                      _query.isEmpty
+                          ? _GeoList(
+                            species: localSpecies,
+                            groups: _groups,
+                            sortMode: _sortMode,
+                            detectionFilter: _detectionFilter,
+                            locationAvailable:
+                                locationAsync.valueOrNull != null,
+                          )
+                          : _SearchResults(
+                            query: _query,
+                            groups: _groups,
+                            sortMode: _sortMode,
+                            detectionFilter: _detectionFilter,
+                            localSpecies: localSpecies,
+                          ),
                 ),
               ],
             );
@@ -392,8 +405,9 @@ class _ExploreSheetHeader extends StatelessWidget {
       padding: const EdgeInsets.only(bottom: 8, top: 4),
       child: Text(
         label,
-        style: theme.textTheme.labelLarge
-            ?.copyWith(color: theme.colorScheme.primary),
+        style: theme.textTheme.labelLarge?.copyWith(
+          color: theme.colorScheme.primary,
+        ),
       ),
     );
   }
@@ -494,31 +508,38 @@ class _GeoList extends ConsumerWidget {
     final l10n = AppLocalizations.of(context)!;
     final detected = ref.watch(detectedSpeciesSetProvider);
 
-    final filtered = species.where((s) {
-      if (groups.isNotEmpty) {
-        final g = s.taxonomy?.taxonGroup;
-        if (g == null || !groups.any((tg) => tg.csvValue == g)) return false;
-      }
-      switch (detectionFilter) {
-        case _DetectionFilter.all:
-          break;
-        case _DetectionFilter.detected:
-          if (!detected.contains(s.scientificName)) return false;
-        case _DetectionFilter.undetected:
-          if (detected.contains(s.scientificName)) return false;
-      }
-      return true;
-    }).toList();
+    final filtered =
+        species.where((s) {
+          if (groups.isNotEmpty) {
+            final g = s.taxonomy?.taxonGroup;
+            if (g == null || !groups.any((tg) => tg.csvValue == g)) {
+              return false;
+            }
+          }
+          switch (detectionFilter) {
+            case _DetectionFilter.all:
+              break;
+            case _DetectionFilter.detected:
+              if (!detected.contains(s.scientificName)) return false;
+            case _DetectionFilter.undetected:
+              if (detected.contains(s.scientificName)) return false;
+          }
+          return true;
+        }).toList();
 
     switch (sortMode) {
       case _SortMode.geo:
         filtered.sort((a, b) => b.geoScore.compareTo(a.geoScore));
       case _SortMode.nameAsc:
-        filtered.sort((a, b) =>
-            a.commonName.toLowerCase().compareTo(b.commonName.toLowerCase()));
+        filtered.sort(
+          (a, b) =>
+              a.commonName.toLowerCase().compareTo(b.commonName.toLowerCase()),
+        );
       case _SortMode.nameDesc:
-        filtered.sort((a, b) =>
-            b.commonName.toLowerCase().compareTo(a.commonName.toLowerCase()));
+        filtered.sort(
+          (a, b) =>
+              b.commonName.toLowerCase().compareTo(a.commonName.toLowerCase()),
+        );
     }
 
     if (filtered.isEmpty) {
@@ -540,12 +561,13 @@ class _GeoList extends ConsumerWidget {
           commonName: s.commonName,
           geoScore: s.geoScore,
           weeklyScores: s.weeklyScores,
-          onTap: () => SpeciesInfoOverlay.show(
-            context,
-            ref,
-            scientificName: s.scientificName,
-            commonName: s.commonName,
-          ),
+          onTap:
+              () => SpeciesInfoOverlay.show(
+                context,
+                ref,
+                scientificName: s.scientificName,
+                commonName: s.commonName,
+              ),
         );
       },
     );
@@ -593,21 +615,26 @@ class _SearchResults extends ConsumerWidget {
     // Search across the entire taxonomy, then keep only species the audio
     // model knows about (so opening them is meaningful), and apply the
     // taxonomic-group + detection-state filters.
-    final hits = taxonomy
-        .search(query, limit: 200)
-        .where((sp) => audioLabels.contains(sp.scientificName))
-        .where((sp) =>
-            groups.isEmpty || groups.any((g) => g.csvValue == sp.taxonGroup))
-        .where((sp) {
-      switch (detectionFilter) {
-        case _DetectionFilter.all:
-          return true;
-        case _DetectionFilter.detected:
-          return detected.contains(sp.scientificName);
-        case _DetectionFilter.undetected:
-          return !detected.contains(sp.scientificName);
-      }
-    }).toList();
+    final hits =
+        taxonomy
+            .search(query, limit: 200)
+            .where((sp) => audioLabels.contains(sp.scientificName))
+            .where(
+              (sp) =>
+                  groups.isEmpty ||
+                  groups.any((g) => g.csvValue == sp.taxonGroup),
+            )
+            .where((sp) {
+              switch (detectionFilter) {
+                case _DetectionFilter.all:
+                  return true;
+                case _DetectionFilter.detected:
+                  return detected.contains(sp.scientificName);
+                case _DetectionFilter.undetected:
+                  return !detected.contains(sp.scientificName);
+              }
+            })
+            .toList();
 
     if (hits.isEmpty) {
       return Center(
@@ -617,8 +644,8 @@ class _SearchResults extends ConsumerWidget {
             l10n.exploreNoResultsFor(query),
             textAlign: TextAlign.center,
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
-                ),
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
           ),
         ),
       );
@@ -650,8 +677,9 @@ class _SearchResults extends ConsumerWidget {
         b.displayName.toLowerCase().compareTo(a.displayName.toLowerCase());
     switch (sortMode) {
       case _SortMode.geo:
-        atLocation.sort((a, b) =>
-            (b.local?.geoScore ?? 0).compareTo(a.local?.geoScore ?? 0));
+        atLocation.sort(
+          (a, b) => (b.local?.geoScore ?? 0).compareTo(a.local?.geoScore ?? 0),
+        );
       case _SortMode.nameAsc:
         atLocation.sort(byNameAsc);
         elsewhere.sort(byNameAsc);
@@ -662,17 +690,21 @@ class _SearchResults extends ConsumerWidget {
 
     final items = <_ListEntry>[];
     if (atLocation.isNotEmpty) {
-      items.add(_ListEntry.header(
-        l10n.exploreSectionAtLocation(atLocation.length),
-        Icons.location_on,
-      ));
+      items.add(
+        _ListEntry.header(
+          l10n.exploreSectionAtLocation(atLocation.length),
+          Icons.location_on,
+        ),
+      );
       items.addAll(atLocation.map(_ListEntry.hit));
     }
     if (elsewhere.isNotEmpty) {
-      items.add(_ListEntry.header(
-        l10n.exploreSectionElsewhere(elsewhere.length),
-        Icons.public,
-      ));
+      items.add(
+        _ListEntry.header(
+          l10n.exploreSectionElsewhere(elsewhere.length),
+          Icons.public,
+        ),
+      );
       items.addAll(elsewhere.map(_ListEntry.hit));
     }
 
@@ -691,12 +723,13 @@ class _SearchResults extends ConsumerWidget {
           commonName: hit.displayName,
           geoScore: hit.local?.geoScore,
           weeklyScores: hit.local?.weeklyScores,
-          onTap: () => SpeciesInfoOverlay.show(
-            context,
-            ref,
-            scientificName: hit.species.scientificName,
-            commonName: hit.species.commonName,
-          ),
+          onTap:
+              () => SpeciesInfoOverlay.show(
+                context,
+                ref,
+                scientificName: hit.species.scientificName,
+                commonName: hit.species.commonName,
+              ),
         );
       },
     );
@@ -718,13 +751,8 @@ class _SearchHit {
 }
 
 class _ListEntry {
-  _ListEntry.header(this.label, this.icon)
-      : isHeader = true,
-        hit = null;
-  _ListEntry.hit(this.hit)
-      : isHeader = false,
-        label = null,
-        icon = null;
+  _ListEntry.header(this.label, this.icon) : isHeader = true, hit = null;
+  _ListEntry.hit(this.hit) : isHeader = false, label = null, icon = null;
 
   final bool isHeader;
   final String? label;
@@ -765,10 +793,7 @@ class _SectionHeader extends StatelessWidget {
 // ---------------------------------------------------------------------------
 
 class _LocationHeader extends ConsumerStatefulWidget {
-  const _LocationHeader({
-    required this.speciesCount,
-    required this.onRefresh,
-  });
+  const _LocationHeader({required this.speciesCount, required this.onRefresh});
 
   final int speciesCount;
   final VoidCallback onRefresh;
@@ -833,7 +858,8 @@ class _LocationHeaderState extends ConsumerState<_LocationHeader> {
                     // Prefer the reverse-geocoded place name; fall back to
                     // raw lat/lon so we don't waste a second row showing
                     // both. While geocoding is in flight, show coordinates.
-                    final label = _locationName ??
+                    final label =
+                        _locationName ??
                         '${loc.latitude.toStringAsFixed(4)}, '
                             '${loc.longitude.toStringAsFixed(4)}';
                     return Text(
@@ -843,18 +869,20 @@ class _LocationHeaderState extends ConsumerState<_LocationHeader> {
                       ),
                     );
                   },
-                  loading: () => Text(
-                    l10n.exploreLocating,
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: theme.colorScheme.onSurface.withAlpha(150),
-                    ),
-                  ),
-                  error: (_, __) => Text(
-                    l10n.exploreLocationError,
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: theme.colorScheme.error,
-                    ),
-                  ),
+                  loading:
+                      () => Text(
+                        l10n.exploreLocating,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurface.withAlpha(150),
+                        ),
+                      ),
+                  error:
+                      (_, __) => Text(
+                        l10n.exploreLocationError,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.error,
+                        ),
+                      ),
                 ),
               ),
               IconButton(
@@ -889,22 +917,13 @@ class _ExploreHelpSheet extends StatelessWidget {
       title: l10n.exploreHelpTitle,
       initialChildSize: 0.62,
       sections: [
-        AppHelpSection(
-          icon: Icons.info_outline,
-          body: l10n.exploreHelpBody,
-        ),
-        AppHelpSection(
-          icon: Icons.refresh,
-          body: l10n.exploreHelpRefresh,
-        ),
+        AppHelpSection(icon: Icons.info_outline, body: l10n.exploreHelpBody),
+        AppHelpSection(icon: Icons.refresh, body: l10n.exploreHelpRefresh),
         AppHelpSection(
           icon: Icons.help_outline_rounded,
           body: l10n.exploreHelpLocation,
         ),
-        AppHelpSection(
-          icon: Icons.search_rounded,
-          body: l10n.exploreHelpCards,
-        ),
+        AppHelpSection(icon: Icons.search_rounded, body: l10n.exploreHelpCards),
       ],
       footer: _ExploreHelpLink(label: l10n.exploreHelpLearnMore),
     );
@@ -921,17 +940,14 @@ class _ExploreHelpLink extends StatelessWidget {
     final theme = Theme.of(context);
 
     return InkWell(
-      onTap: () => openExternalUrl(
-        context,
-        'https://birdnet-team.github.io/geomodel/',
-      ),
+      onTap:
+          () => openExternalUrl(
+            context,
+            'https://birdnet-team.github.io/geomodel/',
+          ),
       child: Row(
         children: [
-          Icon(
-            Icons.open_in_new,
-            size: 18,
-            color: theme.colorScheme.primary,
-          ),
+          Icon(Icons.open_in_new, size: 18, color: theme.colorScheme.primary),
           const SizedBox(width: 8),
           Flexible(
             child: Text(

--- a/lib/features/explore/widgets/pick_wikipedia_url.dart
+++ b/lib/features/explore/widgets/pick_wikipedia_url.dart
@@ -1,0 +1,44 @@
+// =============================================================================
+// pickWikipediaUrl — locale-aware Wikipedia URL resolver
+// =============================================================================
+//
+// Pure helper extracted from `species_info_overlay.dart` so it can be
+// unit-tested without spinning up Riverpod or a widget tree.
+//
+// Resolution order:
+//   1. Bundled URL for the user's effective species locale.
+//   2. Bundled English URL.
+//   3. Constructed English Wikipedia URL from the scientific name
+//      (`https://en.wikipedia.org/wiki/<Genus_species>`). Wikipedia
+//      reliably resolves scientific-name slugs (and redirects most
+//      aliases), so this guarantees the Wikipedia chip is never missing
+//      even when `taxonomy.csv` has no link for the species.
+// =============================================================================
+
+library;
+
+/// Returns the best Wikipedia URL for [scientificName] given the
+/// (optional) per-locale [bundledUrls] map and the user's [locale].
+///
+/// Always returns a non-empty URL; falls back to a constructed English
+/// Wikipedia link if no bundled URL is available.
+String pickWikipediaUrl({
+  required String scientificName,
+  required Map<String, String>? bundledUrls,
+  required String locale,
+}) {
+  if (bundledUrls != null && bundledUrls.isNotEmpty) {
+    final localized = bundledUrls[locale];
+    if (localized != null && localized.isNotEmpty) {
+      return localized;
+    }
+    final english = bundledUrls['en'];
+    if (english != null && english.isNotEmpty) {
+      return english;
+    }
+  }
+  // Fallback: construct an English Wikipedia URL from the scientific
+  // name. Wikipedia URL-encodes spaces as underscores.
+  final slug = scientificName.trim().replaceAll(' ', '_');
+  return 'https://en.wikipedia.org/wiki/${Uri.encodeComponent(slug)}';
+}

--- a/lib/features/explore/widgets/species_info_overlay.dart
+++ b/lib/features/explore/widgets/species_info_overlay.dart
@@ -19,10 +19,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:birdnet_live/l10n/app_localizations.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import '../../../shared/models/taxonomy_species.dart';
 import '../../../shared/providers/settings_providers.dart';
+import '../../../shared/services/link_launcher.dart';
 import '../explore_providers.dart';
 import '../../inference/geo_model.dart';
 import '../../history/global_species_history.dart';
@@ -428,12 +428,7 @@ class _LinkChip extends StatelessWidget {
         ],
       ),
       labelStyle: theme.textTheme.bodySmall,
-      onPressed: () async {
-        final uri = Uri.parse(url);
-        if (await canLaunchUrl(uri)) {
-          await launchUrl(uri, mode: LaunchMode.externalApplication);
-        }
-      },
+      onPressed: () => openExternalUrl(context, url),
     );
   }
 }

--- a/lib/features/explore/widgets/species_info_overlay.dart
+++ b/lib/features/explore/widgets/species_info_overlay.dart
@@ -47,10 +47,11 @@ class SpeciesInfoOverlay {
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
       ),
-      builder: (_) => _SpeciesInfoSheet(
-        scientificName: scientificName,
-        commonName: commonName,
-      ),
+      builder:
+          (_) => _SpeciesInfoSheet(
+            scientificName: scientificName,
+            commonName: commonName,
+          ),
     );
   }
 }
@@ -164,10 +165,11 @@ class _SpeciesInfoSheetState extends ConsumerState<_SpeciesInfoSheet> {
                       _detail?.assetImagePath ??
                           'assets/images/dummy_species.png',
                       fit: BoxFit.contain,
-                      errorBuilder: (_, __, ___) => Image.asset(
-                        'assets/images/dummy_species.png',
-                        fit: BoxFit.contain,
-                      ),
+                      errorBuilder:
+                          (_, __, ___) => Image.asset(
+                            'assets/images/dummy_species.png',
+                            fit: BoxFit.contain,
+                          ),
                     ),
                     if (ref
                         .watch(detectedSpeciesSetProvider)
@@ -200,7 +202,8 @@ class _SpeciesInfoSheetState extends ConsumerState<_SpeciesInfoSheet> {
                 padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
                 child: Text(
                   _detail?.commonNameForLocale(
-                          ref.watch(effectiveSpeciesLocaleProvider)) ??
+                        ref.watch(effectiveSpeciesLocaleProvider),
+                      ) ??
                       widget.commonName,
                   style: theme.textTheme.headlineSmall?.copyWith(
                     fontWeight: FontWeight.w700,
@@ -209,15 +212,16 @@ class _SpeciesInfoSheetState extends ConsumerState<_SpeciesInfoSheet> {
               ),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: ref.watch(showSciNamesProvider)
-                    ? Text(
-                        widget.scientificName,
-                        style: theme.textTheme.bodyLarge?.copyWith(
-                          fontStyle: FontStyle.italic,
-                          color: theme.colorScheme.onSurface.withAlpha(170),
-                        ),
-                      )
-                    : const SizedBox.shrink(),
+                child:
+                    ref.watch(showSciNamesProvider)
+                        ? Text(
+                          widget.scientificName,
+                          style: theme.textTheme.bodyLarge?.copyWith(
+                            fontStyle: FontStyle.italic,
+                            color: theme.colorScheme.onSurface.withAlpha(170),
+                          ),
+                        )
+                        : const SizedBox.shrink(),
               ),
 
               // ── Personal detection stats ─────────────────────
@@ -241,9 +245,7 @@ class _SpeciesInfoSheetState extends ConsumerState<_SpeciesInfoSheet> {
                     padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
                     child: Text(
                       _description!,
-                      style: theme.textTheme.bodyMedium?.copyWith(
-                        height: 1.5,
-                      ),
+                      style: theme.textTheme.bodyMedium?.copyWith(height: 1.5),
                     ),
                   ),
                   if (_detail?.descriptionSource != null)
@@ -262,9 +264,7 @@ class _SpeciesInfoSheetState extends ConsumerState<_SpeciesInfoSheet> {
                 ],
 
                 // ── 48-Week Probability Chart ──────────────────────────────
-                _WeeklyProbabilityChart(
-                  scientificName: widget.scientificName,
-                ),
+                _WeeklyProbabilityChart(scientificName: widget.scientificName),
 
                 // ── External links ───────────────────────────────
                 if (_detail != null) ...[
@@ -483,13 +483,16 @@ class _WeeklyProbabilityChart extends ConsumerWidget {
                 children: [
                   Text(
                     l10n.speciesExpectedFrequency,
-                    style: theme.textTheme.titleMedium
-                        ?.copyWith(fontWeight: FontWeight.bold),
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
                   const SizedBox(width: 8),
                   Container(
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 2,
+                    ),
                     decoration: BoxDecoration(
                       color: categoryColor.withAlpha(30),
                       borderRadius: BorderRadius.circular(8),
@@ -538,20 +541,23 @@ class _WeeklyProbabilityChart extends ConsumerWidget {
                           margin: const EdgeInsets.symmetric(horizontal: 0.5),
                           height: barHeight,
                           decoration: BoxDecoration(
-                            color: isCurrentWeek
-                                ? activeColor
-                                : baseColor.withAlpha(
-                                    (50 + (normalized * 150))
-                                        .toInt()
-                                        .clamp(0, 255),
-                                  ),
+                            color:
+                                isCurrentWeek
+                                    ? activeColor
+                                    : baseColor.withAlpha(
+                                      (50 + (normalized * 150)).toInt().clamp(
+                                        0,
+                                        255,
+                                      ),
+                                    ),
                             borderRadius: BorderRadius.circular(2),
-                            border: isCurrentWeek
-                                ? Border.all(
-                                    color: theme.colorScheme.onSurface,
-                                    width: 1.5,
-                                  )
-                                : null,
+                            border:
+                                isCurrentWeek
+                                    ? Border.all(
+                                      color: theme.colorScheme.onSurface,
+                                      width: 1.5,
+                                    )
+                                    : null,
                           ),
                         ),
                       ),
@@ -566,30 +572,42 @@ class _WeeklyProbabilityChart extends ConsumerWidget {
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  Text(l10n.monthJanShort,
-                      style: const TextStyle(fontSize: 10)),
-                  Text(l10n.monthAprShort,
-                      style: const TextStyle(fontSize: 10)),
-                  Text(l10n.monthJulShort,
-                      style: const TextStyle(fontSize: 10)),
-                  Text(l10n.monthOctShort,
-                      style: const TextStyle(fontSize: 10)),
-                  Text(l10n.monthDecShort,
-                      style: const TextStyle(fontSize: 10)),
+                  Text(
+                    l10n.monthJanShort,
+                    style: const TextStyle(fontSize: 10),
+                  ),
+                  Text(
+                    l10n.monthAprShort,
+                    style: const TextStyle(fontSize: 10),
+                  ),
+                  Text(
+                    l10n.monthJulShort,
+                    style: const TextStyle(fontSize: 10),
+                  ),
+                  Text(
+                    l10n.monthOctShort,
+                    style: const TextStyle(fontSize: 10),
+                  ),
+                  Text(
+                    l10n.monthDecShort,
+                    style: const TextStyle(fontSize: 10),
+                  ),
                 ],
               ),
             ),
           ],
         );
       },
-      loading: () => const Padding(
-        padding: EdgeInsets.all(16),
-        child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
-      ),
-      error: (_, __) => Padding(
-        padding: const EdgeInsets.all(16),
-        child: Center(child: Text(l10n.speciesChartLoadFailed)),
-      ),
+      loading:
+          () => const Padding(
+            padding: EdgeInsets.all(16),
+            child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+          ),
+      error:
+          (_, __) => Padding(
+            padding: const EdgeInsets.all(16),
+            child: Center(child: Text(l10n.speciesChartLoadFailed)),
+          ),
     );
   }
 }
@@ -625,11 +643,7 @@ class _OverlayDetectedBadge extends StatelessWidget {
           ),
         ],
       ),
-      child: Icon(
-        Icons.check,
-        size: 18,
-        color: theme.colorScheme.onPrimary,
-      ),
+      child: Icon(Icons.check, size: 18, color: theme.colorScheme.onPrimary),
     );
   }
 }
@@ -694,8 +708,11 @@ class _DetectionStatsTile extends ConsumerWidget {
             ),
             child: Row(
               children: [
-                Icon(Icons.check_circle,
-                    size: 20, color: theme.colorScheme.primary),
+                Icon(
+                  Icons.check_circle,
+                  size: 20,
+                  color: theme.colorScheme.primary,
+                ),
                 const SizedBox(width: 10),
                 Expanded(
                   child: Column(
@@ -704,7 +721,9 @@ class _DetectionStatsTile extends ConsumerWidget {
                     children: [
                       Text(
                         l10n.speciesYouHaveDetected(
-                            totalDetections, sessionCount),
+                          totalDetections,
+                          sessionCount,
+                        ),
                         style: theme.textTheme.bodyMedium?.copyWith(
                           fontWeight: FontWeight.w600,
                         ),
@@ -728,10 +747,9 @@ class _DetectionStatsTile extends ConsumerWidget {
 
   static String _formatLastSeen(BuildContext context, DateTime dt) {
     final locale = Localizations.localeOf(context).toString();
-    return MaterialLocalizations.of(context)
-            .formatMediumDate(dt.toLocal())
-            .toString()
-            .isNotEmpty
+    return MaterialLocalizations.of(
+          context,
+        ).formatMediumDate(dt.toLocal()).toString().isNotEmpty
         // Fall through to a stable yyyy-MM-dd if the platform localization
         // is unavailable for the active locale (rare on supported devices).
         ? MaterialLocalizations.of(context).formatMediumDate(dt.toLocal())

--- a/lib/features/explore/widgets/species_info_overlay.dart
+++ b/lib/features/explore/widgets/species_info_overlay.dart
@@ -27,6 +27,7 @@ import '../explore_providers.dart';
 import '../../inference/geo_model.dart';
 import '../../history/global_species_history.dart';
 import '../../live/live_providers.dart';
+import 'pick_wikipedia_url.dart';
 
 /// Shows a modal bottom sheet with detailed species information.
 class SpeciesInfoOverlay {
@@ -111,14 +112,14 @@ class _SpeciesInfoSheetState extends ConsumerState<_SpeciesInfoSheet> {
 
   /// Pick the best Wikipedia URL for the active locale.
   ///
-  /// Prefers the user's interface/species locale, falls back to English,
-  /// returns null if neither exists. Only locales bundled in taxonomy.csv
-  /// are considered (interface locales).
-  String? _pickWikipediaUrl(TaxonomySpecies detail) {
-    final urls = detail.wikipediaUrls;
-    if (urls == null || urls.isEmpty) return null;
+  /// Delegates to [pickWikipediaUrl] with the current effective locale.
+  String _pickWikipediaUrl(TaxonomySpecies detail) {
     final locale = ref.read(effectiveSpeciesLocaleProvider);
-    return urls[locale] ?? urls['en'];
+    return pickWikipediaUrl(
+      scientificName: widget.scientificName,
+      bundledUrls: detail.wikipediaUrls,
+      locale: locale,
+    );
   }
 
   @override
@@ -266,10 +267,7 @@ class _SpeciesInfoSheetState extends ConsumerState<_SpeciesInfoSheet> {
                 ),
 
                 // ── External links ───────────────────────────────
-                if (_detail != null &&
-                    (_detail!.ebirdUrl != null ||
-                        _detail!.inatUrl != null ||
-                        _pickWikipediaUrl(_detail!) != null)) ...[
+                if (_detail != null) ...[
                   Padding(
                     padding: const EdgeInsets.fromLTRB(16, 12, 16, 6),
                     child: Text(
@@ -297,12 +295,11 @@ class _SpeciesInfoSheetState extends ConsumerState<_SpeciesInfoSheet> {
                             iconAsset: 'assets/images/icon-inat.png',
                             url: _detail!.inatUrl!,
                           ),
-                        if (_pickWikipediaUrl(_detail!) != null)
-                          _LinkChip(
-                            label: 'Wikipedia',
-                            iconAsset: 'assets/images/icon-wikipedia.png',
-                            url: _pickWikipediaUrl(_detail!)!,
-                          ),
+                        _LinkChip(
+                          label: 'Wikipedia',
+                          iconAsset: 'assets/images/icon-wikipedia.png',
+                          url: _pickWikipediaUrl(_detail!),
+                        ),
                       ],
                     ),
                   ),

--- a/lib/features/home/help_screen.dart
+++ b/lib/features/home/help_screen.dart
@@ -9,9 +9,9 @@
 
 import 'package:flutter/material.dart';
 import 'package:birdnet_live/l10n/app_localizations.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import '../../core/constants/app_constants.dart';
+import '../../shared/services/link_launcher.dart';
 import '../../shared/utils/session_type_visuals.dart';
 import '../../shared/widgets/content_width_constraint.dart';
 import '../live/live_session.dart';
@@ -386,8 +386,5 @@ class _TipRow extends StatelessWidget {
 Future<void> _launchUserGuide(BuildContext context) async {
   final localeCode = Localizations.localeOf(context).languageCode;
   final basePath = localeCode == 'en' ? '' : '/$localeCode';
-  final uri = Uri.parse('${AppConstants.docsUrl}$basePath/user/');
-  if (await canLaunchUrl(uri)) {
-    await launchUrl(uri, mode: LaunchMode.externalApplication);
-  }
+  await openExternalUrl(context, '${AppConstants.docsUrl}$basePath/user/');
 }

--- a/lib/features/home/help_screen.dart
+++ b/lib/features/home/help_screen.dart
@@ -28,168 +28,169 @@ class HelpScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: Text(l10n.helpTitle)),
       body: ContentWidthConstraint(
-          child: ListView(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-        children: [
-          // ── 1. Introduction ─────────────────────────────────
-          // Sets context for everything that follows: what kind of app
-          // this is and how the help page is organized.
-          Text(
-            l10n.helpIntro,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: theme.colorScheme.onSurface.withAlpha(200),
-              height: 1.5,
-            ),
-          ),
-          const SizedBox(height: 20),
-
-          // ── 2. What you can do (the four core capture modes) ──
-          // The user's primary intent on opening the app is to record
-          // and identify something — so the four capture modes come
-          // first, in order of increasing structure / commitment:
-          //   Live  → Point Count → Survey → File Analysis
-          _SectionHeader(
-            icon: Icons.mic_none_outlined,
-            title: l10n.helpModesTitle,
-          ),
-          const SizedBox(height: 12),
-          _HelpSection(
-            icon: sessionTypeIcon(SessionType.live),
-            color: sessionTypeIconColor(SessionType.live),
-            title: l10n.helpLiveTitle,
-            body: l10n.helpLiveBody,
-          ),
-          _HelpSection(
-            icon: sessionTypeIcon(SessionType.pointCount),
-            color: sessionTypeIconColor(SessionType.pointCount),
-            title: l10n.helpPointCountTitle,
-            body: l10n.helpPointCountBody,
-          ),
-          _HelpSection(
-            icon: sessionTypeIcon(SessionType.survey),
-            color: sessionTypeIconColor(SessionType.survey),
-            title: l10n.helpSurveyTitle,
-            body: l10n.helpSurveyBody,
-          ),
-          _HelpSection(
-            icon: sessionTypeIcon(SessionType.fileUpload),
-            color: sessionTypeIconColor(SessionType.fileUpload),
-            title: l10n.helpFileAnalysisTitle,
-            body: l10n.helpFileAnalysisBody,
-          ),
-          const SizedBox(height: 20),
-
-          // ── 3. Discover & revisit (Explore + Session Library) ──
-          // Once the user has captured something — or wants to know
-          // *what to expect* before recording — these two screens are
-          // where they go.
-          _SectionHeader(
-            icon: Icons.travel_explore_outlined,
-            title: l10n.helpToolsTitle,
-          ),
-          const SizedBox(height: 12),
-          _HelpSection(
-            icon: Icons.search_rounded,
-            color: theme.colorScheme.primary,
-            title: l10n.helpExploreTitle,
-            body: l10n.helpExploreBody,
-          ),
-          _HelpSection(
-            icon: Icons.library_music_outlined,
-            color: theme.colorScheme.tertiary,
-            title: l10n.helpSessionsTitle,
-            body: l10n.helpSessionsBody,
-          ),
-          const SizedBox(height: 20),
-
-          // ── 4. Common controls (settings & meta navigation) ──
-          // These are the small AppBar / footer affordances common to
-          // every screen. They follow the modes because users typically
-          // discover them only after they've started using the app.
-          _SectionHeader(
-            icon: Icons.tune_rounded,
-            title: l10n.helpControlsTitle,
-          ),
-          const SizedBox(height: 12),
-          _ControlCard(
-            icon: Icons.tune_rounded,
-            title: l10n.settings,
-            body: l10n.helpControlSettings,
-          ),
-          _ControlCard(
-            icon: Icons.help_outline_rounded,
-            title: l10n.helpTitle,
-            body: l10n.helpControlHelp,
-          ),
-          _ControlCard(
-            icon: Icons.info_outline,
-            title: l10n.about,
-            body: l10n.helpControlAbout,
-          ),
-
-          const SizedBox(height: 8),
-          const Divider(),
-          const SizedBox(height: 8),
-
-          // ── 5. Tips for best results ─────────────────────────
-          _SectionHeader(
-            icon: Icons.lightbulb_outline,
-            title: l10n.helpTipsTitle,
-          ),
-          const SizedBox(height: 12),
-          _TipRow(text: l10n.helpTipQuiet),
-          _TipRow(text: l10n.helpTipMic),
-          _TipRow(text: l10n.helpTipBasics),
-          _TipRow(text: l10n.helpTipThreshold),
-          _TipRow(text: l10n.helpTipGeoFilter),
-          _TipRow(text: l10n.helpTipGuide),
-          const SizedBox(height: 12),
-
-          // ── 6. Deeper dive — link out to the online user guide ──
-          Card(
-            color: theme.colorScheme.surfaceContainerLow,
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
-                    children: [
-                      Icon(
-                        Icons.menu_book_outlined,
-                        size: 20,
-                        color: theme.colorScheme.primary,
-                      ),
-                      const SizedBox(width: 8),
-                      Text(
-                        l10n.aboutUserGuide,
-                        style: theme.textTheme.titleSmall?.copyWith(
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    l10n.helpTipGuide,
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      color: theme.colorScheme.onSurface.withAlpha(180),
-                      height: 1.4,
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-                  FilledButton.tonalIcon(
-                    onPressed: () => _launchUserGuide(context),
-                    icon: const Icon(Icons.open_in_new),
-                    label: Text(l10n.aboutUserGuide),
-                  ),
-                ],
+        child: ListView(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          children: [
+            // ── 1. Introduction ─────────────────────────────────
+            // Sets context for everything that follows: what kind of app
+            // this is and how the help page is organized.
+            Text(
+              l10n.helpIntro,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurface.withAlpha(200),
+                height: 1.5,
               ),
             ),
-          ),
-          const SizedBox(height: 24),
-        ],
-      )),
+            const SizedBox(height: 20),
+
+            // ── 2. What you can do (the four core capture modes) ──
+            // The user's primary intent on opening the app is to record
+            // and identify something — so the four capture modes come
+            // first, in order of increasing structure / commitment:
+            //   Live  → Point Count → Survey → File Analysis
+            _SectionHeader(
+              icon: Icons.mic_none_outlined,
+              title: l10n.helpModesTitle,
+            ),
+            const SizedBox(height: 12),
+            _HelpSection(
+              icon: sessionTypeIcon(SessionType.live),
+              color: sessionTypeIconColor(SessionType.live),
+              title: l10n.helpLiveTitle,
+              body: l10n.helpLiveBody,
+            ),
+            _HelpSection(
+              icon: sessionTypeIcon(SessionType.pointCount),
+              color: sessionTypeIconColor(SessionType.pointCount),
+              title: l10n.helpPointCountTitle,
+              body: l10n.helpPointCountBody,
+            ),
+            _HelpSection(
+              icon: sessionTypeIcon(SessionType.survey),
+              color: sessionTypeIconColor(SessionType.survey),
+              title: l10n.helpSurveyTitle,
+              body: l10n.helpSurveyBody,
+            ),
+            _HelpSection(
+              icon: sessionTypeIcon(SessionType.fileUpload),
+              color: sessionTypeIconColor(SessionType.fileUpload),
+              title: l10n.helpFileAnalysisTitle,
+              body: l10n.helpFileAnalysisBody,
+            ),
+            const SizedBox(height: 20),
+
+            // ── 3. Discover & revisit (Explore + Session Library) ──
+            // Once the user has captured something — or wants to know
+            // *what to expect* before recording — these two screens are
+            // where they go.
+            _SectionHeader(
+              icon: Icons.travel_explore_outlined,
+              title: l10n.helpToolsTitle,
+            ),
+            const SizedBox(height: 12),
+            _HelpSection(
+              icon: Icons.search_rounded,
+              color: theme.colorScheme.primary,
+              title: l10n.helpExploreTitle,
+              body: l10n.helpExploreBody,
+            ),
+            _HelpSection(
+              icon: Icons.library_music_outlined,
+              color: theme.colorScheme.tertiary,
+              title: l10n.helpSessionsTitle,
+              body: l10n.helpSessionsBody,
+            ),
+            const SizedBox(height: 20),
+
+            // ── 4. Common controls (settings & meta navigation) ──
+            // These are the small AppBar / footer affordances common to
+            // every screen. They follow the modes because users typically
+            // discover them only after they've started using the app.
+            _SectionHeader(
+              icon: Icons.tune_rounded,
+              title: l10n.helpControlsTitle,
+            ),
+            const SizedBox(height: 12),
+            _ControlCard(
+              icon: Icons.tune_rounded,
+              title: l10n.settings,
+              body: l10n.helpControlSettings,
+            ),
+            _ControlCard(
+              icon: Icons.help_outline_rounded,
+              title: l10n.helpTitle,
+              body: l10n.helpControlHelp,
+            ),
+            _ControlCard(
+              icon: Icons.info_outline,
+              title: l10n.about,
+              body: l10n.helpControlAbout,
+            ),
+
+            const SizedBox(height: 8),
+            const Divider(),
+            const SizedBox(height: 8),
+
+            // ── 5. Tips for best results ─────────────────────────
+            _SectionHeader(
+              icon: Icons.lightbulb_outline,
+              title: l10n.helpTipsTitle,
+            ),
+            const SizedBox(height: 12),
+            _TipRow(text: l10n.helpTipQuiet),
+            _TipRow(text: l10n.helpTipMic),
+            _TipRow(text: l10n.helpTipBasics),
+            _TipRow(text: l10n.helpTipThreshold),
+            _TipRow(text: l10n.helpTipGeoFilter),
+            _TipRow(text: l10n.helpTipGuide),
+            const SizedBox(height: 12),
+
+            // ── 6. Deeper dive — link out to the online user guide ──
+            Card(
+              color: theme.colorScheme.surfaceContainerLow,
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Icon(
+                          Icons.menu_book_outlined,
+                          size: 20,
+                          color: theme.colorScheme.primary,
+                        ),
+                        const SizedBox(width: 8),
+                        Text(
+                          l10n.aboutUserGuide,
+                          style: theme.textTheme.titleSmall?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      l10n.helpTipGuide,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.colorScheme.onSurface.withAlpha(180),
+                        height: 1.4,
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    FilledButton.tonalIcon(
+                      onPressed: () => _launchUserGuide(context),
+                      icon: const Icon(Icons.open_in_new),
+                      label: Text(l10n.aboutUserGuide),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 24),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/features/onboarding/onboarding_screen.dart
+++ b/lib/features/onboarding/onboarding_screen.dart
@@ -25,10 +25,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:birdnet_live/l10n/app_localizations.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:record/record.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import '../../core/constants/app_constants.dart';
 import '../../shared/providers/app_providers.dart';
+import '../../shared/services/link_launcher.dart';
 import '../../shared/widgets/content_width_constraint.dart';
 
 // ---------------------------------------------------------------------------
@@ -682,8 +682,7 @@ class _TermsPage extends StatelessWidget {
   Future<void> _open(BuildContext context, String path) async {
     final localeCode = Localizations.localeOf(context).languageCode;
     final basePath = localeCode == 'en' ? '' : '/$localeCode';
-    final uri = Uri.parse('${AppConstants.docsUrl}$basePath$path');
-    await launchUrl(uri, mode: LaunchMode.externalApplication);
+    await openExternalUrl(context, '${AppConstants.docsUrl}$basePath$path');
   }
 
   @override

--- a/lib/features/onboarding/onboarding_screen.dart
+++ b/lib/features/onboarding/onboarding_screen.dart
@@ -85,7 +85,8 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
       final loc = await Geolocator.checkPermission();
       if (!mounted) return;
       setState(() {
-        _locGranted = loc == LocationPermission.whileInUse ||
+        _locGranted =
+            loc == LocationPermission.whileInUse ||
             loc == LocationPermission.always;
       });
     } catch (_) {
@@ -118,7 +119,8 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
       }
       if (!mounted) return;
       setState(() {
-        _locGranted = perm == LocationPermission.whileInUse ||
+        _locGranted =
+            perm == LocationPermission.whileInUse ||
             perm == LocationPermission.always;
       });
     } catch (_) {
@@ -217,8 +219,8 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                     l10n: l10n,
                     theme: theme,
                     agreed: _termsAgreed,
-                    onAgreedChanged: (v) =>
-                        setState(() => _termsAgreed = v ?? false),
+                    onAgreedChanged:
+                        (v) => setState(() => _termsAgreed = v ?? false),
                   ),
                 ],
               ),
@@ -292,9 +294,10 @@ class _ControlsBar extends StatelessWidget {
                     width: i == page ? 18 : 8,
                     height: 8,
                     decoration: BoxDecoration(
-                      color: i == page
-                          ? theme.colorScheme.primary
-                          : theme.colorScheme.outlineVariant,
+                      color:
+                          i == page
+                              ? theme.colorScheme.primary
+                              : theme.colorScheme.outlineVariant,
                       borderRadius: BorderRadius.circular(4),
                     ),
                   ),
@@ -593,10 +596,7 @@ class _PermissionTile extends StatelessWidget {
       decoration: BoxDecoration(
         color: theme.colorScheme.surfaceContainerHighest.withAlpha(120),
         borderRadius: BorderRadius.circular(14),
-        border: Border.all(
-          color: theme.colorScheme.outlineVariant,
-          width: 1,
-        ),
+        border: Border.all(color: theme.colorScheme.outlineVariant, width: 1),
       ),
       padding: const EdgeInsets.all(14),
       child: Row(
@@ -609,8 +609,11 @@ class _PermissionTile extends StatelessWidget {
               color: theme.colorScheme.primaryContainer,
               borderRadius: BorderRadius.circular(10),
             ),
-            child: Icon(icon,
-                size: 22, color: theme.colorScheme.onPrimaryContainer),
+            child: Icon(
+              icon,
+              size: 22,
+              color: theme.colorScheme.onPrimaryContainer,
+            ),
           ),
           const SizedBox(width: 12),
           Expanded(
@@ -619,8 +622,9 @@ class _PermissionTile extends StatelessWidget {
               children: [
                 Text(
                   title,
-                  style: theme.textTheme.titleSmall
-                      ?.copyWith(fontWeight: FontWeight.w600),
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
                 const SizedBox(height: 2),
                 Text(
@@ -647,13 +651,14 @@ class _PermissionTile extends StatelessWidget {
                 style: FilledButton.styleFrom(
                   padding: const EdgeInsets.symmetric(horizontal: 14),
                 ),
-                child: busy
-                    ? const SizedBox(
-                        width: 16,
-                        height: 16,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
-                    : Text(l10n.permissionRequest),
+                child:
+                    busy
+                        ? const SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                        : Text(l10n.permissionRequest),
               ),
             ),
         ],
@@ -756,10 +761,7 @@ class _TermsPage extends StatelessWidget {
                 padding: const EdgeInsets.symmetric(vertical: 6),
                 child: Row(
                   children: [
-                    Checkbox(
-                      value: agreed,
-                      onChanged: onAgreedChanged,
-                    ),
+                    Checkbox(value: agreed, onChanged: onAgreedChanged),
                     Expanded(
                       child: Text(
                         l10n.onboardingTermsAccept,

--- a/lib/features/spectrogram/color_maps.dart
+++ b/lib/features/spectrogram/color_maps.dart
@@ -146,14 +146,26 @@ abstract final class SpectrogramColorMap {
 
       // Linearly interpolate each ARGB channel.
       // Color.a/.r/.g/.b return doubles in [0.0, 1.0] — scale to [0, 255].
-      final a =
-          _lerpInt((lo.color.a * 255).round(), (hi.color.a * 255).round(), f);
-      final r =
-          _lerpInt((lo.color.r * 255).round(), (hi.color.r * 255).round(), f);
-      final g =
-          _lerpInt((lo.color.g * 255).round(), (hi.color.g * 255).round(), f);
-      final b =
-          _lerpInt((lo.color.b * 255).round(), (hi.color.b * 255).round(), f);
+      final a = _lerpInt(
+        (lo.color.a * 255).round(),
+        (hi.color.a * 255).round(),
+        f,
+      );
+      final r = _lerpInt(
+        (lo.color.r * 255).round(),
+        (hi.color.r * 255).round(),
+        f,
+      );
+      final g = _lerpInt(
+        (lo.color.g * 255).round(),
+        (hi.color.g * 255).round(),
+        f,
+      );
+      final b = _lerpInt(
+        (lo.color.b * 255).round(),
+        (hi.color.b * 255).round(),
+        f,
+      );
 
       // Pack into ARGB8888 integer.
       table[i] = (a << 24) | (r << 16) | (g << 8) | b;

--- a/lib/features/spectrogram/color_maps.dart
+++ b/lib/features/spectrogram/color_maps.dart
@@ -105,8 +105,12 @@ abstract final class SpectrogramColorMap {
       _GradientStop(1.00, const Color(0xFFFCFFA4)),
     ],
     'grayscale': [
-      _GradientStop(0.00, const Color(0xFF000000)),
-      _GradientStop(1.00, const Color(0xFFFFFFFF)),
+      // White = quiet, black = loud — matches Audacity, Raven, Sonic
+      // Visualiser, matplotlib's `gray_r`, and printed sonograms in field
+      // guides. Reversed from the natural black→white ramp so quiet
+      // background reads as paper-white instead of a black wall (#33).
+      _GradientStop(0.00, const Color(0xFFFFFFFF)),
+      _GradientStop(1.00, const Color(0xFF000000)),
     ],
     // Brand-themed color map: dark navy → brand blue (#0D6EFD) → white.
     'birdnet': [

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -685,5 +685,6 @@
   "sessionHelpTopBar": "Horní lišta používá zavřít k opuštění Revize relace a nastavení k otevření úplné obrazovky nastavení. Aktuální relace zůstává načtena, zatímco kontrolujete přehrávání, detekce a poznámky.",
   "sessionHelpUndoRedo": "Zpět a znovu posunují úpravy provedené během aktuální revize o krok zpět nebo vpřed.",
   "sessionHelpSaveDiscard": "Uložit zapíše vaše změny, sdílet exportuje balíček relace, zahodit odstraní uloženou relaci a tlačítko nápovědy znovu otevře tento panel.",
-  "sessionHelpContinueSurvey": "U relací survey tlačítko přehrávání pokračuje v nahrávání ve stejné survey místo spuštění nové."
+  "sessionHelpContinueSurvey": "U relací survey tlačítko přehrávání pokračuje v nahrávání ve stejné survey místo spuštění nové.",
+  "linkOpenFailedCopied": "Odkaz se nepodařilo otevřít. URL byla zkopírována do schránky."
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -685,5 +685,6 @@
   "sessionHelpTopBar": "Die obere Leiste verwendet Schließen, um die Session-Überprüfung zu verlassen, und Einstellungen, um den vollständigen Einstellungsbildschirm zu öffnen. Ihre aktuelle Session bleibt geladen, während Sie Wiedergabe, Detektionen und Notizen prüfen.",
   "sessionHelpUndoRedo": "Rückgängig und Wiederholen gehen bei Bearbeitungen der aktuellen Überprüfung einen Schritt zurück oder vor.",
   "sessionHelpSaveDiscard": "Speichern schreibt Ihre Änderungen, Teilen exportiert das Session-Bundle, Verwerfen entfernt die gespeicherte Session, und die Hilfe-Schaltfläche öffnet dieses Overlay erneut.",
-  "sessionHelpContinueSurvey": "Bei Survey-Sessions setzt die Play-Schaltfläche die Aufnahme in derselben Survey fort, anstatt eine neue zu starten."
+  "sessionHelpContinueSurvey": "Bei Survey-Sessions setzt die Play-Schaltfläche die Aufnahme in derselben Survey fort, anstatt eine neue zu starten.",
+  "linkOpenFailedCopied": "Link konnte nicht geöffnet werden. URL in die Zwischenablage kopiert."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2670,5 +2670,9 @@
   "sessionHelpContinueSurvey": "For survey sessions, the play button continues recording into the same survey instead of starting a separate one.",
   "@sessionHelpContinueSurvey": {
     "description": "Explains the continue survey action on the Session Review help overlay"
+  },
+  "linkOpenFailedCopied": "Couldn't open link. URL copied to clipboard.",
+  "@linkOpenFailedCopied": {
+    "description": "Snackbar shown when launching an external https/mailto URL fails (e.g. no browser installed). The URL is copied to the clipboard so the user can paste it elsewhere."
   }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -685,5 +685,6 @@
   "sessionHelpTopBar": "La barra superior usa cerrar para salir de Revisión de sesión y ajustes para abrir la pantalla completa de ajustes. La sesión actual permanece cargada mientras revisas reproducción, detecciones y notas.",
   "sessionHelpUndoRedo": "Deshacer y rehacer retroceden o avanzan un paso en las ediciones hechas durante la revisión actual.",
   "sessionHelpSaveDiscard": "Guardar escribe tus cambios, compartir exporta el paquete de sesión, descartar elimina la sesión guardada y el botón de ayuda vuelve a abrir este panel.",
-  "sessionHelpContinueSurvey": "En sesiones de survey, el botón de reproducir continúa la grabación en la misma survey en lugar de iniciar una nueva."
+  "sessionHelpContinueSurvey": "En sesiones de survey, el botón de reproducir continúa la grabación en la misma survey en lugar de iniciar una nueva.",
+  "linkOpenFailedCopied": "No se pudo abrir el enlace. URL copiada al portapapeles."
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -685,5 +685,6 @@
   "sessionHelpTopBar": "La barre supérieure utilise fermer pour quitter Révision de session et réglages pour ouvrir l'écran complet des réglages. La session en cours reste chargée pendant que vous examinez lecture, détections et notes.",
   "sessionHelpUndoRedo": "Annuler et rétablir reviennent en arrière ou avancent d'une étape dans les modifications effectuées pendant la révision en cours.",
   "sessionHelpSaveDiscard": "Enregistrer écrit vos modifications, partager exporte l'ensemble de session, abandonner supprime la session enregistrée, et le bouton d'aide rouvre ce panneau.",
-  "sessionHelpContinueSurvey": "Pour les sessions de relevé, le bouton lecture poursuit l'enregistrement dans le même relevé au lieu d'en démarrer un nouveau."
+  "sessionHelpContinueSurvey": "Pour les sessions de relevé, le bouton lecture poursuit l'enregistrement dans le même relevé au lieu d'en démarrer un nouveau.",
+  "linkOpenFailedCopied": "Impossible d'ouvrir le lien. URL copiée dans le presse-papiers."
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -685,5 +685,6 @@
   "sessionHelpTopBar": "La barra superiore usa chiudi per lasciare Revisione sessione e impostazioni per aprire la schermata completa delle impostazioni. La sessione corrente resta caricata mentre controlli riproduzione, rilevazioni e note.",
   "sessionHelpUndoRedo": "Annulla e ripristina spostano indietro o avanti di un passaggio nelle modifiche fatte durante la revisione corrente.",
   "sessionHelpSaveDiscard": "Salva scrive le modifiche, condividi esporta il pacchetto della sessione, scarta rimuove la sessione salvata e il pulsante di aiuto riapre questo pannello.",
-  "sessionHelpContinueSurvey": "Per le sessioni di survey, il pulsante play continua la registrazione nella stessa survey invece di iniziarne una nuova."
+  "sessionHelpContinueSurvey": "Per le sessioni di survey, il pulsante play continua la registrazione nella stessa survey invece di iniziarne una nuova.",
+  "linkOpenFailedCopied": "Impossibile aprire il link. URL copiato negli appunti."
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -685,5 +685,6 @@
   "sessionHelpTopBar": "A barra superior usa fechar para sair da Revisão de sessão e configurações para abrir a tela completa de configurações. A sessão atual permanece carregada enquanto você inspeciona reprodução, detecções e notas.",
   "sessionHelpUndoRedo": "Desfazer e refazer voltam ou avançam um passo nas edições feitas durante a revisão atual.",
   "sessionHelpSaveDiscard": "Salvar grava suas alterações, compartilhar exporta o pacote da sessão, descartar remove a sessão salva e o botão de ajuda reabre este painel.",
-  "sessionHelpContinueSurvey": "Para sessões de survey, o botão de play continua a gravação na mesma survey em vez de iniciar uma nova."
+  "sessionHelpContinueSurvey": "Para sessões de survey, o botão de play continua a gravação na mesma survey em vez de iniciar uma nova.",
+  "linkOpenFailedCopied": "Não foi possível abrir o link. URL copiado para a área de transferência."
 }

--- a/lib/shared/services/link_launcher.dart
+++ b/lib/shared/services/link_launcher.dart
@@ -1,0 +1,58 @@
+// =============================================================================
+// Link Launcher — Safe external URL launching with user-visible fallback
+// =============================================================================
+//
+// Wraps `url_launcher` so call sites don't have to repeat the same boilerplate
+// (try/catch + SnackBar + clipboard copy). The previous pattern of
+// `if (await canLaunchUrl(uri)) launchUrl(uri)` silently no-ops on Android 11+
+// when the manifest's `<queries>` block doesn't list `ACTION_VIEW` for the
+// scheme — the symptom seen in issue #34 on a Pixel 9 Pro. Two changes
+// together fix it:
+//
+//   1. `AndroidManifest.xml` declares `<intent>` queries for http/https/mailto
+//      so Android grants visibility to browsers and mail apps.
+//   2. We drop the `canLaunchUrl` probe entirely and just call `launchUrl`
+//      inside try/catch. If it throws (e.g. no browser installed at all), we
+//      copy the URL to the clipboard and show a SnackBar telling the user.
+//
+// ### Usage
+//
+// ```dart
+// await openExternalUrl(context, 'https://example.org/');
+// ```
+// =============================================================================
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../l10n/app_localizations.dart';
+
+/// Opens [url] in an external app (browser, mail client, …).
+///
+/// On failure the URL is copied to the clipboard and a SnackBar is shown via
+/// the nearest [ScaffoldMessenger]. Pass [context] so we can surface that
+/// fallback; if the widget is unmounted by the time the launch fails the
+/// SnackBar is silently skipped.
+Future<void> openExternalUrl(BuildContext context, String url) async {
+  final uri = Uri.parse(url);
+  try {
+    final ok = await launchUrl(uri, mode: LaunchMode.externalApplication);
+    if (ok) return;
+    // launchUrl returned false — fall through to the failure path.
+    throw PlatformException(code: 'launch_failed', message: 'launchUrl returned false');
+  } catch (_) {
+    // Clipboard access doesn't need a BuildContext; do that first so we still
+    // hand the user a working URL even if the widget tree was torn down
+    // between the failed launch and this fallback.
+    await Clipboard.setData(ClipboardData(text: url));
+    if (!context.mounted) return;
+    final l10n = AppLocalizations.of(context)!;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(l10n.linkOpenFailedCopied),
+        duration: const Duration(seconds: 4),
+      ),
+    );
+  }
+}

--- a/lib/shared/services/link_launcher.dart
+++ b/lib/shared/services/link_launcher.dart
@@ -40,7 +40,10 @@ Future<void> openExternalUrl(BuildContext context, String url) async {
     final ok = await launchUrl(uri, mode: LaunchMode.externalApplication);
     if (ok) return;
     // launchUrl returned false — fall through to the failure path.
-    throw PlatformException(code: 'launch_failed', message: 'launchUrl returned false');
+    throw PlatformException(
+      code: 'launch_failed',
+      message: 'launchUrl returned false',
+    );
   } catch (_) {
     // Clipboard access doesn't need a BuildContext; do that first so we still
     // hand the user a working URL even if the widget tree was torn down

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: birdnet_live
 description: "Real-time bird species identification using on-device ONNX inference"
 publish_to: 'none'
-version: 0.9.4+100
+version: 0.9.5+101
 
 environment:
   sdk: ^3.7.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: birdnet_live
 description: "Real-time bird species identification using on-device ONNX inference"
 publish_to: 'none'
-version: 0.9.3+99
+version: 0.9.4+100
 
 environment:
   sdk: ^3.7.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: birdnet_live
 description: "Real-time bird species identification using on-device ONNX inference"
 publish_to: 'none'
-version: 0.9.5+101
+version: 0.9.6+102
 
 environment:
   sdk: ^3.7.0

--- a/test/features/explore/pick_wikipedia_url_test.dart
+++ b/test/features/explore/pick_wikipedia_url_test.dart
@@ -18,9 +18,7 @@ void main() {
     test('falls back to English when locale missing', () {
       final url = pickWikipediaUrl(
         scientificName: 'Parus major',
-        bundledUrls: const {
-          'en': 'https://en.wikipedia.org/wiki/Great_tit',
-        },
+        bundledUrls: const {'en': 'https://en.wikipedia.org/wiki/Great_tit'},
         locale: 'fr',
       );
       expect(url, 'https://en.wikipedia.org/wiki/Great_tit');

--- a/test/features/explore/pick_wikipedia_url_test.dart
+++ b/test/features/explore/pick_wikipedia_url_test.dart
@@ -1,0 +1,86 @@
+import 'package:birdnet_live/features/explore/widgets/pick_wikipedia_url.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('pickWikipediaUrl', () {
+    test('returns localized URL when available', () {
+      final url = pickWikipediaUrl(
+        scientificName: 'Parus major',
+        bundledUrls: const {
+          'en': 'https://en.wikipedia.org/wiki/Great_tit',
+          'de': 'https://de.wikipedia.org/wiki/Kohlmeise',
+        },
+        locale: 'de',
+      );
+      expect(url, 'https://de.wikipedia.org/wiki/Kohlmeise');
+    });
+
+    test('falls back to English when locale missing', () {
+      final url = pickWikipediaUrl(
+        scientificName: 'Parus major',
+        bundledUrls: const {
+          'en': 'https://en.wikipedia.org/wiki/Great_tit',
+        },
+        locale: 'fr',
+      );
+      expect(url, 'https://en.wikipedia.org/wiki/Great_tit');
+    });
+
+    test('falls back to English when localized entry is empty string', () {
+      final url = pickWikipediaUrl(
+        scientificName: 'Parus major',
+        bundledUrls: const {
+          'en': 'https://en.wikipedia.org/wiki/Great_tit',
+          'de': '',
+        },
+        locale: 'de',
+      );
+      expect(url, 'https://en.wikipedia.org/wiki/Great_tit');
+    });
+
+    test('constructs scientific-name URL when bundledUrls is null', () {
+      final url = pickWikipediaUrl(
+        scientificName: 'Parus major',
+        bundledUrls: null,
+        locale: 'en',
+      );
+      expect(url, 'https://en.wikipedia.org/wiki/Parus_major');
+    });
+
+    test('constructs scientific-name URL when bundledUrls is empty', () {
+      final url = pickWikipediaUrl(
+        scientificName: 'Loxia curvirostra',
+        bundledUrls: const {},
+        locale: 'de',
+      );
+      expect(url, 'https://en.wikipedia.org/wiki/Loxia_curvirostra');
+    });
+
+    test('constructs scientific-name URL when no usable bundled entries', () {
+      final url = pickWikipediaUrl(
+        scientificName: 'Loxia curvirostra',
+        bundledUrls: const {'de': ''},
+        locale: 'de',
+      );
+      expect(url, 'https://en.wikipedia.org/wiki/Loxia_curvirostra');
+    });
+
+    test('URL-encodes scientific names with special characters', () {
+      final url = pickWikipediaUrl(
+        scientificName: "Pica pica",
+        bundledUrls: null,
+        locale: 'en',
+      );
+      expect(url, 'https://en.wikipedia.org/wiki/Pica_pica');
+    });
+
+    test('trims surrounding whitespace from scientific name', () {
+      final url = pickWikipediaUrl(
+        scientificName: '  Parus major  ',
+        bundledUrls: null,
+        locale: 'en',
+      );
+      expect(url, 'https://en.wikipedia.org/wiki/Parus_major');
+    });
+  });
+}

--- a/test/features/spectrogram/color_maps_test.dart
+++ b/test/features/spectrogram/color_maps_test.dart
@@ -103,12 +103,12 @@ void main() {
     // ─── Specific palette spot checks ──────────────────────────────────────
 
     group('spot checks', () {
-      test('grayscale starts black and ends white', () {
+      test('grayscale starts white and ends black', () {
         final table = SpectrogramColorMap.lut('grayscale');
-        // Index 0 → black.
-        expect(table[0] & 0x00FFFFFF, 0x00000000);
-        // Index 255 → white.
-        expect(table[255] & 0x00FFFFFF, 0x00FFFFFF);
+        // Index 0 → white (quiet/background).
+        expect(table[0] & 0x00FFFFFF, 0x00FFFFFF);
+        // Index 255 → black (loud).
+        expect(table[255] & 0x00FFFFFF, 0x00000000);
       });
 
       test('birdnet mid-range is near brand blue (#0D6EFD)', () {

--- a/test/features/spectrogram/color_maps_test.dart
+++ b/test/features/spectrogram/color_maps_test.dart
@@ -37,8 +37,11 @@ void main() {
           final table = SpectrogramColorMap.lut(name);
           for (var i = 0; i < 256; i++) {
             final alpha = (table[i] >> 24) & 0xFF;
-            expect(alpha, 255,
-                reason: '$name LUT[$i] should have alpha=255, got $alpha');
+            expect(
+              alpha,
+              255,
+              reason: '$name LUT[$i] should have alpha=255, got $alpha',
+            );
           }
         });
       }
@@ -92,9 +95,12 @@ void main() {
             final dg = (((curr >> 8) & 0xFF) - ((prev >> 8) & 0xFF)).abs();
             final db = ((curr & 0xFF) - (prev & 0xFF)).abs();
             final maxDelta = [dr, dg, db].reduce((a, b) => a > b ? a : b);
-            expect(maxDelta, lessThan(30),
-                reason:
-                    '$name LUT[$i] has a $maxDelta-step jump from LUT[${i - 1}]');
+            expect(
+              maxDelta,
+              lessThan(30),
+              reason:
+                  '$name LUT[$i] has a $maxDelta-step jump from LUT[${i - 1}]',
+            );
           }
         });
       }


### PR DESCRIPTION
This update addresses several issues, including ensuring that external links (e.g., Wikipedia, eBird, iNaturalist) open reliably on Android 11 and above. The grayscale colormap for the spectrogram has been inverted to enhance usability, aligning with common visual standards. Additionally, the app version has been updated to 0.9.6. Minor formatting adjustments were also made for consistency.