### PR TITLE
Add Dynamic Color support and update semantic UI colors #56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.3] - 2026-05-18
+
+### Added
+
+- **Dynamic Color (Material You) toggle in Settings.** A new switch under Settings → Appearance lets you opt into your Android device's dynamic color palette instead of the BirdNET brand theme. On Android 12+ the app's surfaces, primary accents, and chrome rebuild against the wallpaper-derived palette so BirdNET visually matches the rest of your launcher. No effect on iPhone or iPad (kept off by default everywhere so first-launch users still see the brand theme).
+
+### Changed
+
+- **Semantic UI colors routed through the theme.** Success greens, the "confirmed" checkmark, and the four session-mode accents (Live red, Point Count blue, Survey green, File Analysis orange) are no longer hardcoded across widgets. They now live in a single `AppSemanticColors` theme extension that provides the brand hues under the default theme and harmonizes them against the active palette in dynamic-color mode. Survey map markers, the audio-quality bars, the onboarding permission checks, the live and clip-player confirmed toggles, and the session review cluster checkmarks all read from this token set, so the same widgets stay legible whether you're on the brand theme, a light dynamic palette, or a dark one. No behavioral changes — purely a visual consistency pass.
+
 ## [0.14.2] - 2026-05-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
   <img src="https://img.shields.io/badge/flutter-%3E%3D3.0-blue.svg" alt="Flutter">
   <img src="https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Windows-green.svg" alt="Platforms">
-  <img src="https://img.shields.io/badge/version-0.14.2-orange.svg" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.14.3-orange.svg" alt="Version">
   <img src="https://img.shields.io/badge/species-5%2C250-brightgreen.svg" alt="Species: 5,250">
 </p>
 

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -13,6 +13,8 @@ BirdNET Live reuses one Settings screen across multiple workflows. The :material
 
 Choose **Dark**, **Light**, or **System**.
 
+If **Dynamic Color** is enabled, BirdNET Live also tries to use your Android device's system palette. This only does something on supported Android devices; on iPhone and iPad the app keeps using the normal BirdNET Live theme, so turning the toggle on there changes nothing.
+
 ### App Language
 
 Sets the interface language.

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,3 +1,4 @@
+import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -19,31 +20,49 @@ class App extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final themeMode = ref.watch(themeModeProvider);
+    final useDynamicColor = ref.watch(dynamicColorProvider);
     final locale = ref.watch(localeProvider);
 
-    return MaterialApp(
-      onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
-      debugShowCheckedModeBanner: false,
+    return DynamicColorBuilder(
+      builder: (ColorScheme? lightDynamic, ColorScheme? darkDynamic) {
+        // Use the platform's dynamic palette when the user has opted in
+        // and the OS provides one. Otherwise fall back to the brand theme.
+        final ThemeData lightTheme;
+        final ThemeData darkTheme;
 
-      // Theme
-      theme: AppTheme.light(),
-      darkTheme: AppTheme.dark(),
-      themeMode: themeMode,
+        if (useDynamicColor && lightDynamic != null && darkDynamic != null) {
+          lightTheme = AppTheme.fromColorScheme(lightDynamic.harmonized());
+          darkTheme = AppTheme.fromColorScheme(darkDynamic.harmonized());
+        } else {
+          lightTheme = AppTheme.light();
+          darkTheme = AppTheme.dark();
+        }
 
-      // Localization
-      locale: locale,
-      localizationsDelegates: const [
-        AppLocalizations.delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-      ],
-      supportedLocales: AppLocalizations.supportedLocales,
+        return MaterialApp(
+          onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
+          debugShowCheckedModeBanner: false,
 
-      // Initial screen based on app state
-      home: const AnnouncementsAccessibilityDefaultApplier(
-        child: _AppGate(),
-      ),
+          // Theme
+          theme: lightTheme,
+          darkTheme: darkTheme,
+          themeMode: themeMode,
+
+          // Localization
+          locale: locale,
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+
+          // Initial screen based on app state
+          home: const AnnouncementsAccessibilityDefaultApplier(
+            child: _AppGate(),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -49,6 +49,7 @@ abstract final class PrefKeys {
   static const String onboardingComplete = 'onboarding_complete';
   static const String termsAccepted = 'terms_accepted';
   static const String themeMode = 'theme_mode';
+  static const String dynamicColor = 'dynamic_color';
   static const String locale = 'locale';
   static const String speciesLanguage = 'species_language';
 

--- a/lib/core/theme/app_semantic_colors.dart
+++ b/lib/core/theme/app_semantic_colors.dart
@@ -1,0 +1,170 @@
+import 'package:dynamic_color/dynamic_color.dart';
+import 'package:flutter/material.dart';
+
+// =============================================================================
+// AppSemanticColors — theme extension for non-score semantic UI colors
+// =============================================================================
+//
+// Holds semantic tokens that are not part of Flutter's built-in ColorScheme,
+// such as success-state greens and the four distinct session-mode accent
+// colors. The default BirdNET theme uses the app's existing brand hues,
+// while dynamic-color mode harmonizes the same roles against the active
+// Android palette so widgets can stay theme-driven.
+// =============================================================================
+
+@immutable
+class AppSemanticColors extends ThemeExtension<AppSemanticColors> {
+  const AppSemanticColors({
+    required this.success,
+    required this.onSuccess,
+    required this.successContainer,
+    required this.onSuccessContainer,
+    required this.sessionLive,
+    required this.sessionPointCount,
+    required this.sessionSurvey,
+    required this.sessionFileAnalysis,
+  });
+
+  final Color success;
+  final Color onSuccess;
+  final Color successContainer;
+  final Color onSuccessContainer;
+  final Color sessionLive;
+  final Color sessionPointCount;
+  final Color sessionSurvey;
+  final Color sessionFileAnalysis;
+
+  static const Color _successBase = Color(0xFF43A047);
+  static const Color _successContainerLight = Color(0xFFD7F0DA);
+  static const Color _successContainerForegroundLight = Color(0xFF1B5E20);
+  static const Color _liveBase = Color(0xFFE53935);
+  static const Color _pointCountBase = Color(0xFF1E88E5);
+  static const Color _surveyBase = Color(0xFF43A047);
+  static const Color _fileAnalysisBase = Color(0xFFFB8C00);
+
+  static const AppSemanticColors light = AppSemanticColors(
+    success: _successBase,
+    onSuccess: Colors.white,
+    successContainer: _successContainerLight,
+    onSuccessContainer: _successContainerForegroundLight,
+    sessionLive: _liveBase,
+    sessionPointCount: _pointCountBase,
+    sessionSurvey: _surveyBase,
+    sessionFileAnalysis: _fileAnalysisBase,
+  );
+
+  static AppSemanticColors dark(ColorScheme colorScheme) {
+    return AppSemanticColors(
+      success: _successBase,
+      onSuccess: Colors.white,
+      successContainer: Color.alphaBlend(
+        _successBase.withAlpha(48),
+        colorScheme.surfaceContainerHigh,
+      ),
+      onSuccessContainer: Colors.white,
+      sessionLive: _liveBase,
+      sessionPointCount: _pointCountBase,
+      sessionSurvey: _surveyBase,
+      sessionFileAnalysis: _fileAnalysisBase,
+    );
+  }
+
+  /// Harmonized variant for dynamic-color themes — the brand semantic hues
+  /// are blended toward the active OS palette's primary so they coexist
+  /// with Material You without losing their meaning (success still reads
+  /// as green-ish, mode accents stay distinguishable, etc.).
+  static AppSemanticColors harmonized(ColorScheme colorScheme) {
+    final success = _successBase.harmonizeWith(colorScheme.primary);
+    final isDark = colorScheme.brightness == Brightness.dark;
+    final successContainer = Color.alphaBlend(
+      success.withAlpha(isDark ? 44 : 20),
+      colorScheme.surfaceContainerHigh,
+    );
+    // Pick a foreground that always survives against the success-tinted
+    // container: white on dark, the deepened success hue on light. Using
+    // the raw success color here would collapse contrast in light mode.
+    final onSuccessContainer =
+        isDark
+            ? Colors.white
+            : Color.alphaBlend(Colors.black.withAlpha(120), success);
+
+    return AppSemanticColors(
+      success: success,
+      onSuccess: _onColorFor(success),
+      successContainer: successContainer,
+      onSuccessContainer: onSuccessContainer,
+      sessionLive: _liveBase.harmonizeWith(colorScheme.primary),
+      sessionPointCount: _pointCountBase.harmonizeWith(colorScheme.primary),
+      sessionSurvey: _surveyBase.harmonizeWith(colorScheme.primary),
+      sessionFileAnalysis: _fileAnalysisBase.harmonizeWith(colorScheme.primary),
+    );
+  }
+
+  static AppSemanticColors of(BuildContext context) =>
+      fromTheme(Theme.of(context));
+
+  /// [ThemeData]-based companion to [of] for callers (utility functions,
+  /// painters) that already hold a [ThemeData] but no [BuildContext].
+  /// Falls back to the brightness-appropriate brand defaults so the result
+  /// stays sensible even when the extension is missing (tests, previews).
+  static AppSemanticColors fromTheme(ThemeData theme) {
+    final ext = theme.extension<AppSemanticColors>();
+    if (ext != null) return ext;
+    return theme.brightness == Brightness.dark
+        ? dark(theme.colorScheme)
+        : light;
+  }
+
+  static Color _onColorFor(Color color) {
+    return ThemeData.estimateBrightnessForColor(color) == Brightness.dark
+        ? Colors.white
+        : Colors.black;
+  }
+
+  @override
+  AppSemanticColors copyWith({
+    Color? success,
+    Color? onSuccess,
+    Color? successContainer,
+    Color? onSuccessContainer,
+    Color? sessionLive,
+    Color? sessionPointCount,
+    Color? sessionSurvey,
+    Color? sessionFileAnalysis,
+  }) {
+    return AppSemanticColors(
+      success: success ?? this.success,
+      onSuccess: onSuccess ?? this.onSuccess,
+      successContainer: successContainer ?? this.successContainer,
+      onSuccessContainer: onSuccessContainer ?? this.onSuccessContainer,
+      sessionLive: sessionLive ?? this.sessionLive,
+      sessionPointCount: sessionPointCount ?? this.sessionPointCount,
+      sessionSurvey: sessionSurvey ?? this.sessionSurvey,
+      sessionFileAnalysis: sessionFileAnalysis ?? this.sessionFileAnalysis,
+    );
+  }
+
+  @override
+  AppSemanticColors lerp(ThemeExtension<AppSemanticColors>? other, double t) {
+    if (other is! AppSemanticColors) return this;
+    return AppSemanticColors(
+      success: Color.lerp(success, other.success, t) ?? success,
+      onSuccess: Color.lerp(onSuccess, other.onSuccess, t) ?? onSuccess,
+      successContainer:
+          Color.lerp(successContainer, other.successContainer, t) ??
+          successContainer,
+      onSuccessContainer:
+          Color.lerp(onSuccessContainer, other.onSuccessContainer, t) ??
+          onSuccessContainer,
+      sessionLive: Color.lerp(sessionLive, other.sessionLive, t) ?? sessionLive,
+      sessionPointCount:
+          Color.lerp(sessionPointCount, other.sessionPointCount, t) ??
+          sessionPointCount,
+      sessionSurvey:
+          Color.lerp(sessionSurvey, other.sessionSurvey, t) ?? sessionSurvey,
+      sessionFileAnalysis:
+          Color.lerp(sessionFileAnalysis, other.sessionFileAnalysis, t) ??
+          sessionFileAnalysis,
+    );
+  }
+}

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'app_semantic_colors.dart';
 import 'score_colors.dart';
 
 // =============================================================================
@@ -28,6 +29,9 @@ import 'score_colors.dart';
 /// Call [AppTheme.dark] or [AppTheme.light] to obtain a fully-configured
 /// [ThemeData] with Material 3 enabled, the brand blue palette, and
 /// component-level overrides (buttons, cards, switches, sliders, etc.).
+///
+/// Call [AppTheme.fromColorScheme] to build a theme from an externally
+/// provided [ColorScheme] (e.g. from the `dynamic_color` package).
 abstract final class AppTheme {
   // ---------------------------------------------------------------------------
   // Brand palette constants (shared between both themes)
@@ -82,109 +86,7 @@ abstract final class AppTheme {
       outline: Color(0xFF5C5C5C),
     );
 
-    return ThemeData(
-      useMaterial3: true,
-      colorScheme: colorScheme,
-      brightness: Brightness.dark,
-      scaffoldBackgroundColor: colorScheme.surface,
-      extensions: const <ThemeExtension<dynamic>>[ScoreColors.dark],
-
-      // ── App Bar ──
-      appBarTheme: AppBarTheme(
-        backgroundColor: colorScheme.surface,
-        foregroundColor: colorScheme.onSurface,
-        elevation: 0,
-        centerTitle: false,
-      ),
-
-      // ── Bottom Navigation ──
-      navigationBarTheme: NavigationBarThemeData(
-        backgroundColor: const Color(0xFF1E1E1E),
-        indicatorColor: colorScheme.primaryContainer,
-        labelBehavior: NavigationDestinationLabelBehavior.alwaysShow,
-        height: 64,
-      ),
-
-      // ── Cards ──
-      cardTheme: CardThemeData(
-        color: const Color(0xFF1E1E1E),
-        elevation: 0,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-        ),
-      ),
-
-      // ── List Tiles ──
-      listTileTheme: _sharedListTileTheme(),
-
-      // ── Dialogs ──
-      dialogTheme: DialogThemeData(
-        backgroundColor: const Color(0xFF1E1E1E),
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(16),
-        ),
-      ),
-
-      // ── Switches ──
-      switchTheme: SwitchThemeData(
-        thumbColor: WidgetStateProperty.resolveWith((states) {
-          if (states.contains(WidgetState.selected)) {
-            return colorScheme.primary;
-          }
-          return colorScheme.outline;
-        }),
-        trackColor: WidgetStateProperty.resolveWith((states) {
-          if (states.contains(WidgetState.selected)) {
-            return colorScheme.primaryContainer;
-          }
-          return colorScheme.surfaceContainerHighest;
-        }),
-      ),
-
-      // ── Sliders ──
-      sliderTheme: SliderThemeData(
-        activeTrackColor: colorScheme.primary,
-        inactiveTrackColor: colorScheme.surfaceContainerHighest,
-        thumbColor: colorScheme.primary,
-        overlayColor: colorScheme.primary.withAlpha(30),
-      ),
-
-      // ── Elevated Buttons (48 dp touch target) ──
-      elevatedButtonTheme: ElevatedButtonThemeData(
-        style: ElevatedButton.styleFrom(
-          backgroundColor: colorScheme.primaryContainer,
-          foregroundColor: colorScheme.onPrimaryContainer,
-          minimumSize: const Size(64, 48),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(12),
-          ),
-        ),
-      ),
-
-      // ── Text Buttons ──
-      textButtonTheme: TextButtonThemeData(
-        style: TextButton.styleFrom(
-          foregroundColor: colorScheme.primary,
-          minimumSize: const Size(48, 48),
-        ),
-      ),
-
-      // ── Dividers ──
-      dividerTheme: const DividerThemeData(
-        color: Color(0xFF2C2C2C),
-        thickness: 1,
-      ),
-
-      // ── Snack Bars ──
-      snackBarTheme: SnackBarThemeData(
-        backgroundColor: const Color(0xFF2C2C2C),
-        contentTextStyle: const TextStyle(color: Color(0xFFE0E0E0)),
-        behavior: SnackBarBehavior.floating,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(8),
-        ),
-      ),
-    );
+    return _buildThemeData(colorScheme, Brightness.dark);
   }
 
   // ─── Light Theme ───────────────────────────────────────────────────────────
@@ -214,12 +116,51 @@ abstract final class AppTheme {
       outline: Color(0xFFBDBDBD),
     );
 
+    return _buildThemeData(colorScheme, Brightness.light);
+  }
+
+  // ─── Dynamic Color ─────────────────────────────────────────────────────────
+
+  /// Build a theme from an externally provided [ColorScheme], typically
+  /// obtained from the `dynamic_color` package's [DynamicColorBuilder].
+  ///
+  /// Applies the same component-level overrides (button shapes, card radii,
+  /// touch targets, etc.) as the brand themes so the app layout and UX
+  /// remain identical — only the palette changes.
+  static ThemeData fromColorScheme(ColorScheme colorScheme) {
+    return _buildThemeData(colorScheme, colorScheme.brightness);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Shared theme builder
+  // ---------------------------------------------------------------------------
+
+  /// Internal factory that wires a [ColorScheme] into a fully-configured
+  /// [ThemeData] with component-level overrides.
+  ///
+  /// Both the brand themes ([dark], [light]) and dynamic-color themes
+  /// ([fromColorScheme]) funnel through here so every variant gets
+  /// identical structural styling (shapes, padding, touch targets).
+  static ThemeData _buildThemeData(
+    ColorScheme colorScheme,
+    Brightness brightness,
+  ) {
+    final isDark = brightness == Brightness.dark;
+    final isBrandTheme = _isBrandThemeColorScheme(colorScheme);
+
     return ThemeData(
       useMaterial3: true,
       colorScheme: colorScheme,
-      brightness: Brightness.light,
+      brightness: brightness,
       scaffoldBackgroundColor: colorScheme.surface,
-      extensions: const <ThemeExtension<dynamic>>[ScoreColors.light],
+      extensions: <ThemeExtension<dynamic>>[
+        isDark ? ScoreColors.dark : ScoreColors.light,
+        isBrandTheme
+            ? (isDark
+                ? AppSemanticColors.dark(colorScheme)
+                : AppSemanticColors.light)
+            : AppSemanticColors.harmonized(colorScheme),
+      ],
 
       // ── App Bar ──
       appBarTheme: AppBarTheme(
@@ -231,7 +172,12 @@ abstract final class AppTheme {
 
       // ── Bottom Navigation ──
       navigationBarTheme: NavigationBarThemeData(
-        backgroundColor: Colors.white,
+        backgroundColor:
+            isBrandTheme
+                ? (isDark ? const Color(0xFF1E1E1E) : Colors.white)
+                : (isDark
+                    ? colorScheme.surfaceContainerHigh
+                    : colorScheme.surfaceContainerLow),
         indicatorColor: colorScheme.primaryContainer,
         labelBehavior: NavigationDestinationLabelBehavior.alwaysShow,
         height: 64,
@@ -239,24 +185,28 @@ abstract final class AppTheme {
 
       // ── Cards ──
       cardTheme: CardThemeData(
-        color: Colors.white,
-        elevation: 1,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-        ),
+        color:
+            isBrandTheme
+                ? (isDark ? const Color(0xFF1E1E1E) : Colors.white)
+                : (isDark
+                    ? colorScheme.surfaceContainerHigh
+                    : colorScheme.surfaceContainerLow),
+        elevation: isDark ? 0 : 1,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       ),
 
       // ── List Tiles ──
-      // (Mirrors the dark theme so spacing/padding stay identical when
-      // toggling brightness.)
       listTileTheme: _sharedListTileTheme(),
 
       // ── Dialogs ──
       dialogTheme: DialogThemeData(
-        backgroundColor: Colors.white,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(16),
-        ),
+        backgroundColor:
+            isBrandTheme
+                ? (isDark ? const Color(0xFF1E1E1E) : Colors.white)
+                : (isDark
+                    ? colorScheme.surfaceContainerHigh
+                    : colorScheme.surfaceContainerLow),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       ),
 
       // ── Switches ──
@@ -283,11 +233,13 @@ abstract final class AppTheme {
         overlayColor: colorScheme.primary.withAlpha(30),
       ),
 
-      // ── Elevated Buttons ──
+      // ── Elevated Buttons (48 dp touch target) ──
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ElevatedButton.styleFrom(
-          backgroundColor: colorScheme.primary,
-          foregroundColor: colorScheme.onPrimary,
+          backgroundColor:
+              isDark ? colorScheme.primaryContainer : colorScheme.primary,
+          foregroundColor:
+              isDark ? colorScheme.onPrimaryContainer : colorScheme.onPrimary,
           minimumSize: const Size(64, 48),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(12),
@@ -304,21 +256,41 @@ abstract final class AppTheme {
       ),
 
       // ── Dividers ──
-      dividerTheme: const DividerThemeData(
-        color: Color(0xFFE0E0E0),
+      dividerTheme: DividerThemeData(
+        color:
+            isBrandTheme
+                ? (isDark ? const Color(0xFF2C2C2C) : const Color(0xFFE0E0E0))
+                : colorScheme.outlineVariant,
         thickness: 1,
       ),
 
       // ── Snack Bars ──
       snackBarTheme: SnackBarThemeData(
-        backgroundColor: const Color(0xFF323232),
-        contentTextStyle: const TextStyle(color: Colors.white),
-        behavior: SnackBarBehavior.floating,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(8),
+        backgroundColor:
+            isBrandTheme
+                ? (isDark ? const Color(0xFF2C2C2C) : const Color(0xFF323232))
+                : (isDark
+                    ? colorScheme.surfaceContainerHighest
+                    : colorScheme.inverseSurface),
+        contentTextStyle: TextStyle(
+          color:
+              isBrandTheme
+                  ? (isDark ? const Color(0xFFE0E0E0) : Colors.white)
+                  : (isDark
+                      ? colorScheme.onSurface
+                      : colorScheme.onInverseSurface),
         ),
+        behavior: SnackBarBehavior.floating,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
       ),
     );
+  }
+
+  static bool _isBrandThemeColorScheme(ColorScheme colorScheme) {
+    return (colorScheme.primary == brandPrimary &&
+            colorScheme.primaryContainer == brandPrimaryContainer) ||
+        (colorScheme.primary == brandPrimaryLight &&
+            colorScheme.primaryContainer == brandPrimaryContainerDark);
   }
 
   // ---------------------------------------------------------------------------
@@ -336,9 +308,7 @@ abstract final class AppTheme {
   static ListTileThemeData _sharedListTileTheme() {
     return ListTileThemeData(
       contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(8),
-      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
       minVerticalPadding: 8,
     );
   }

--- a/lib/features/explore/widgets/species_card.dart
+++ b/lib/features/explore/widgets/species_card.dart
@@ -366,7 +366,7 @@ class _DetectedBadge extends StatelessWidget {
         shape: BoxShape.circle,
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withAlpha(60),
+            color: theme.colorScheme.shadow.withAlpha(60),
             blurRadius: 2,
             offset: const Offset(0, 1),
           ),

--- a/lib/features/explore/widgets/species_info_overlay.dart
+++ b/lib/features/explore/widgets/species_info_overlay.dart
@@ -637,7 +637,7 @@ class _OverlayDetectedBadge extends StatelessWidget {
         shape: BoxShape.circle,
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withAlpha(80),
+            color: theme.colorScheme.shadow.withAlpha(80),
             blurRadius: 3,
             offset: const Offset(0, 1),
           ),

--- a/lib/features/history/session_library_screen.dart
+++ b/lib/features/history/session_library_screen.dart
@@ -636,7 +636,7 @@ class _SessionLibraryScreenState extends ConsumerState<SessionLibraryScreen> {
                 ListTile(
                   leading: Icon(
                     sessionTypeIcon(m.type),
-                    color: sessionTypeIconColor(m.type),
+                    color: sessionTypeAccentColor(theme, m.type),
                   ),
                   title: Text(m.label),
                   subtitle: Text(
@@ -776,12 +776,12 @@ class _SessionTile extends ConsumerWidget {
                     width: 48,
                     height: 48,
                     decoration: BoxDecoration(
-                      color: sessionTypeIconColor(session.type).withAlpha(40),
+                      color: sessionTypeContainerColor(theme, session.type),
                       borderRadius: BorderRadius.circular(12),
                     ),
                     child: Icon(
                       sessionTypeIcon(session.type),
-                      color: sessionTypeIconColor(session.type),
+                      color: sessionTypeAccentColor(theme, session.type),
                     ),
                   ),
                   const SizedBox(width: 16),
@@ -980,7 +980,7 @@ class _CompactSessionTile extends ConsumerWidget {
     return ListTile(
       leading: Icon(
         sessionTypeIcon(session.type),
-        color: sessionTypeIconColor(session.type),
+        color: sessionTypeAccentColor(theme, session.type),
       ),
       title: Text(
         _sessionCardTitle(l10n, session),
@@ -1181,7 +1181,7 @@ class _SpeciesGroupedView extends ConsumerWidget {
                 leading: Icon(
                   sessionTypeIcon(session.type),
                   size: 20,
-                  color: sessionTypeIconColor(session.type),
+                  color: sessionTypeAccentColor(theme, session.type),
                 ),
                 title: Text(
                   _sessionCardTitle(l10n, session),
@@ -1258,7 +1258,8 @@ class _NewSessionFab extends StatelessWidget {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context)!;
     final modeLabel = _sessionTypeLabel(l10n, mode);
-    final modeColor = sessionTypeIconColor(mode);
+    final modeColor = sessionTypeAccentColor(theme, mode);
+    final modeOnColor = sessionTypeOnAccentColor(theme, mode);
     // Use the surface-tinted FAB color so the white mode glyph (live red,
     // survey green, etc.) reads cleanly without competing with the app's
     // primary brand color. Keep elevation/shape consistent with FAB.
@@ -1299,7 +1300,7 @@ class _NewSessionFab extends StatelessWidget {
                         child: Icon(
                           sessionTypeIcon(mode),
                           size: 18,
-                          color: Colors.white,
+                          color: modeOnColor,
                         ),
                       ),
                       const SizedBox(width: 10),

--- a/lib/features/history/session_review_screen.dart
+++ b/lib/features/history/session_review_screen.dart
@@ -61,6 +61,7 @@ import 'package:share_plus/share_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../core/constants/app_constants.dart';
+import '../../core/theme/app_semantic_colors.dart';
 import '../../core/theme/score_colors.dart';
 import '../../shared/models/gps_point.dart';
 import '../../shared/models/taxonomy_species.dart';
@@ -71,6 +72,7 @@ import '../../shared/services/taxonomy_service.dart';
 import '../../shared/utils/timestamp_format.dart';
 import '../../shared/utils/weather_format.dart';
 import '../../shared/widgets/app_help_bottom_sheet.dart';
+import '../../shared/widgets/confirm_destructive.dart';
 import '../../shared/widgets/stat_chip.dart';
 import '../explore/explore_providers.dart';
 import '../explore/widgets/species_info_overlay.dart';
@@ -671,6 +673,9 @@ class _SessionReviewScreenState extends ConsumerState<SessionReviewScreen> {
             content: Text(l10n.sessionUnsavedChanges),
             actions: [
               TextButton(
+                style: TextButton.styleFrom(
+                  foregroundColor: Theme.of(ctx).colorScheme.error,
+                ),
                 onPressed: () => Navigator.of(ctx).pop('discard'),
                 child: Text(l10n.sessionDiscard),
               ),
@@ -756,25 +761,14 @@ class _SessionReviewScreenState extends ConsumerState<SessionReviewScreen> {
 
   Future<void> _discard() async {
     final l10n = AppLocalizations.of(context)!;
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder:
-          (ctx) => AlertDialog(
-            title: Text(l10n.sessionDiscardTitle),
-            content: Text(l10n.sessionDiscardMessage),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(ctx).pop(false),
-                child: Text(l10n.cancel),
-              ),
-              TextButton(
-                onPressed: () => Navigator.of(ctx).pop(true),
-                child: Text(l10n.sessionDiscard),
-              ),
-            ],
-          ),
+    final confirmed = await confirmDestructive(
+      context,
+      title: l10n.sessionDiscardTitle,
+      body: l10n.sessionDiscardMessage,
+      confirmLabel: l10n.sessionDiscard,
+      cancelLabel: l10n.cancel,
     );
-    if (confirmed != true || !mounted) return;
+    if (!confirmed || !mounted) return;
 
     final repo = ref.read(sessionRepositoryProvider);
     await repo.delete(widget.session.id);

--- a/lib/features/history/widgets/clip_player_sheet.dart
+++ b/lib/features/history/widgets/clip_player_sheet.dart
@@ -27,6 +27,7 @@ import 'package:intl/intl.dart';
 import 'package:just_audio/just_audio.dart';
 
 import '../../../core/constants/app_constants.dart';
+import '../../../core/theme/app_semantic_colors.dart';
 import '../../../core/theme/score_colors.dart';
 import '../../../shared/providers/settings_providers.dart';
 import '../../explore/explore_providers.dart';
@@ -794,7 +795,7 @@ class _ConfirmToggle extends StatelessWidget {
             size: 28,
             color:
                 confirmed
-                    ? Colors.green.shade600
+                    ? AppSemanticColors.of(context).success
                     : theme.colorScheme.onSurface.withAlpha(120),
           ),
         ),

--- a/lib/features/history/widgets/session_review_widgets.dart
+++ b/lib/features/history/widgets/session_review_widgets.dart
@@ -1103,7 +1103,8 @@ class _SpeciesTile extends ConsumerWidget {
                                   child: Icon(
                                     Icons.check_circle,
                                     size: 14,
-                                    color: Colors.green.shade600,
+                                    color:
+                                        AppSemanticColors.of(context).success,
                                   ),
                                 ),
                               if (group.allRecords.any(
@@ -1509,7 +1510,7 @@ class _ClusterRow extends ConsumerWidget {
                     size: 24,
                     color:
                         confirmed
-                            ? Colors.green.shade600
+                            ? AppSemanticColors.of(context).success
                             : theme.colorScheme.onSurface.withAlpha(100),
                   ),
                 ),

--- a/lib/features/home/help_screen.dart
+++ b/lib/features/home/help_screen.dart
@@ -24,6 +24,7 @@ class HelpScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
+    final isBrandTheme = isBrandThemeColorScheme(theme.colorScheme);
 
     return Scaffold(
       appBar: AppBar(title: Text(l10n.helpTitle)),
@@ -55,25 +56,59 @@ class HelpScreen extends StatelessWidget {
             const SizedBox(height: 12),
             _HelpSection(
               icon: sessionTypeIcon(SessionType.live),
-              color: sessionTypeIconColor(SessionType.live),
+              color: sessionTypeAccentColor(theme, SessionType.live),
+              containerColor:
+                  isBrandTheme
+                      ? sessionTypeAccentColor(
+                        theme,
+                        SessionType.live,
+                      ).withAlpha(30)
+                      : sessionTypeContainerColor(theme, SessionType.live),
               title: l10n.helpLiveTitle,
               body: l10n.helpLiveBody,
             ),
             _HelpSection(
               icon: sessionTypeIcon(SessionType.pointCount),
-              color: sessionTypeIconColor(SessionType.pointCount),
+              color: sessionTypeAccentColor(theme, SessionType.pointCount),
+              containerColor:
+                  isBrandTheme
+                      ? sessionTypeAccentColor(
+                        theme,
+                        SessionType.pointCount,
+                      ).withAlpha(30)
+                      : sessionTypeContainerColor(
+                        theme,
+                        SessionType.pointCount,
+                      ),
               title: l10n.helpPointCountTitle,
               body: l10n.helpPointCountBody,
             ),
             _HelpSection(
               icon: sessionTypeIcon(SessionType.survey),
-              color: sessionTypeIconColor(SessionType.survey),
+              color: sessionTypeAccentColor(theme, SessionType.survey),
+              containerColor:
+                  isBrandTheme
+                      ? sessionTypeAccentColor(
+                        theme,
+                        SessionType.survey,
+                      ).withAlpha(30)
+                      : sessionTypeContainerColor(theme, SessionType.survey),
               title: l10n.helpSurveyTitle,
               body: l10n.helpSurveyBody,
             ),
             _HelpSection(
               icon: sessionTypeIcon(SessionType.fileUpload),
-              color: sessionTypeIconColor(SessionType.fileUpload),
+              color: sessionTypeAccentColor(theme, SessionType.fileUpload),
+              containerColor:
+                  isBrandTheme
+                      ? sessionTypeAccentColor(
+                        theme,
+                        SessionType.fileUpload,
+                      ).withAlpha(30)
+                      : sessionTypeContainerColor(
+                        theme,
+                        SessionType.fileUpload,
+                      ),
               title: l10n.helpFileAnalysisTitle,
               body: l10n.helpFileAnalysisBody,
             ),
@@ -91,12 +126,14 @@ class HelpScreen extends StatelessWidget {
             _HelpSection(
               icon: Icons.search_rounded,
               color: theme.colorScheme.primary,
+              containerColor: theme.colorScheme.primaryContainer,
               title: l10n.helpExploreTitle,
               body: l10n.helpExploreBody,
             ),
             _HelpSection(
-              icon: Icons.library_music_outlined,
-              color: theme.colorScheme.tertiary,
+              icon: Icons.library_books_outlined,
+              color: theme.colorScheme.secondary,
+              containerColor: theme.colorScheme.secondaryContainer,
               title: l10n.helpSessionsTitle,
               body: l10n.helpSessionsBody,
             ),
@@ -232,12 +269,14 @@ class _HelpSection extends StatelessWidget {
   const _HelpSection({
     required this.icon,
     required this.color,
+    required this.containerColor,
     required this.title,
     required this.body,
   });
 
   final IconData icon;
   final Color color;
+  final Color containerColor;
   final String title;
   final String body;
 
@@ -255,7 +294,7 @@ class _HelpSection extends StatelessWidget {
           width: 36,
           height: 36,
           decoration: BoxDecoration(
-            color: color.withAlpha(30),
+            color: containerColor,
             borderRadius: BorderRadius.circular(10),
           ),
           child: Icon(icon, color: color, size: 20),

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -218,28 +218,28 @@ class _ModeGrid extends StatelessWidget {
             icon: sessionTypeIcon(SessionType.live),
             label: l10n.liveMode,
             description: l10n.liveModeDescription,
-            color: sessionTypeIconColor(SessionType.live),
+            accentColor: sessionTypeAccentColor(theme, SessionType.live),
             onTap: () => _openLive(context),
           ),
           _ModeCard(
             icon: sessionTypeIcon(SessionType.pointCount),
             label: l10n.pointCountMode,
             description: l10n.pointCountModeDescription,
-            color: sessionTypeIconColor(SessionType.pointCount),
+            accentColor: sessionTypeAccentColor(theme, SessionType.pointCount),
             onTap: () => _openPointCount(context),
           ),
           _ModeCard(
             icon: sessionTypeIcon(SessionType.survey),
             label: l10n.surveyMode,
             description: l10n.surveyModeDescription,
-            color: sessionTypeIconColor(SessionType.survey),
+            accentColor: sessionTypeAccentColor(theme, SessionType.survey),
             onTap: () => _openSurvey(context),
           ),
           _ModeCard(
             icon: sessionTypeIcon(SessionType.fileUpload),
             label: l10n.fileAnalysisMode,
             description: l10n.fileAnalysisModeDescription,
-            color: sessionTypeIconColor(SessionType.fileUpload),
+            accentColor: sessionTypeAccentColor(theme, SessionType.fileUpload),
             onTap: () => _openFileAnalysis(context),
           ),
         ],
@@ -281,29 +281,45 @@ class _ModeCard extends StatelessWidget {
     required this.icon,
     required this.label,
     required this.description,
-    required this.color,
+    required this.accentColor,
     this.onTap,
   });
 
   final IconData icon;
   final String label;
   final String description;
-  final Color color;
+  final Color accentColor;
   final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final isDark = theme.brightness == Brightness.dark;
+    final isBrandTheme = isBrandThemeColorScheme(theme.colorScheme);
+    final cardColor =
+        isBrandTheme
+            ? (theme.brightness == Brightness.dark
+                ? theme.colorScheme.surfaceContainerHighest.withAlpha(120)
+                : theme.colorScheme.surfaceContainerHighest.withAlpha(180))
+            : (theme.brightness == Brightness.dark
+                ? theme.colorScheme.surfaceContainerHighest
+                : theme.colorScheme.surfaceContainerHigh);
+    final shape = RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(20),
+      side:
+          isBrandTheme
+              ? BorderSide.none
+              : BorderSide(
+                color: theme.colorScheme.outlineVariant.withAlpha(140),
+              ),
+    );
 
     return Material(
-      color:
-          isDark
-              ? theme.colorScheme.surfaceContainerHighest.withAlpha(120)
-              : theme.colorScheme.surfaceContainerHighest.withAlpha(180),
-      borderRadius: BorderRadius.circular(20),
+      color: cardColor,
+      elevation: isBrandTheme ? 0 : 1,
+      shape: shape,
       child: InkWell(
-        borderRadius: BorderRadius.circular(20),
+        customBorder: shape,
         onTap: onTap,
         child: Padding(
           padding: const EdgeInsets.all(16),
@@ -315,16 +331,20 @@ class _ModeCard extends StatelessWidget {
                 width: 44,
                 height: 44,
                 decoration: BoxDecoration(
-                  color: color.withAlpha(isDark ? 50 : 30),
+                  color:
+                      isBrandTheme
+                          ? accentColor.withAlpha(isDark ? 50 : 30)
+                          : accentColor.withAlpha(36),
                   borderRadius: BorderRadius.circular(14),
                 ),
-                child: Icon(icon, color: color, size: 24),
+                child: Icon(icon, color: accentColor, size: 24),
               ),
               const Spacer(),
               Text(
                 label,
                 style: theme.textTheme.titleSmall?.copyWith(
                   fontWeight: FontWeight.w600,
+                  color: theme.colorScheme.onSurface,
                 ),
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,

--- a/lib/features/live/widgets/detection_list_widget.dart
+++ b/lib/features/live/widgets/detection_list_widget.dart
@@ -16,6 +16,7 @@ import 'package:flutter/material.dart';
 import 'package:birdnet_live/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/theme/app_semantic_colors.dart';
 import '../../../core/theme/score_colors.dart';
 import '../../../shared/providers/settings_providers.dart';
 import '../../../shared/services/taxonomy_service.dart';
@@ -298,7 +299,7 @@ class DetectionTile extends ConsumerWidget {
                 size: 24,
                 color:
                     actions.isConfirmed
-                        ? Colors.green.shade600
+                        ? AppSemanticColors.of(context).success
                         : theme.colorScheme.onSurface.withAlpha(120),
               ),
             ),

--- a/lib/features/onboarding/onboarding_screen.dart
+++ b/lib/features/onboarding/onboarding_screen.dart
@@ -23,6 +23,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:birdnet_live/l10n/app_localizations.dart';
+
+import '../../core/theme/app_semantic_colors.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:record/record.dart';
 
@@ -640,7 +642,7 @@ class _PermissionTile extends StatelessWidget {
           if (granted)
             Icon(
               Icons.check_circle_rounded,
-              color: Colors.green.shade600,
+              color: AppSemanticColors.of(context).success,
               size: 28,
             )
           else

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -125,6 +125,7 @@ class SettingsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
 
     return Scaffold(
       appBar: AppBar(title: Text(l10n.settings)),
@@ -138,6 +139,13 @@ class SettingsScreen extends ConsumerWidget {
                 subtitle: l10n.settingsGeneralDescription,
               ),
               _ThemeTile(l10n: l10n),
+              SwitchListTile(
+                title: Text(l10n.settingsDynamicColor),
+                subtitle: Text(l10n.settingsDynamicColorDescription),
+                value: ref.watch(dynamicColorProvider),
+                onChanged:
+                    (v) => ref.read(dynamicColorProvider.notifier).set(v),
+              ),
               _LanguageTile(l10n: l10n),
               _SpeciesLanguageTile(l10n: l10n),
               SwitchListTile(
@@ -692,7 +700,7 @@ class SettingsScreen extends ConsumerWidget {
               ListTile(
                 title: Text(
                   l10n.settingsClearData,
-                  style: const TextStyle(color: Colors.red),
+                  style: TextStyle(color: theme.colorScheme.error),
                 ),
                 onTap: () => _showClearDataDialog(context, ref, l10n),
               ),
@@ -742,39 +750,44 @@ class SettingsScreen extends ConsumerWidget {
   ) {
     showDialog<void>(
       context: context,
-      builder:
-          (dialogContext) => AlertDialog(
-            title: Text(l10n.settingsResetAllConfirmTitle),
-            content: Text(l10n.settingsResetAllConfirmMessage),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(dialogContext).pop(),
-                child: Text(l10n.cancel),
+      builder: (dialogContext) {
+        final theme = Theme.of(dialogContext);
+        return AlertDialog(
+          title: Text(l10n.settingsResetAllConfirmTitle),
+          content: Text(l10n.settingsResetAllConfirmMessage),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: Text(l10n.cancel),
+            ),
+            FilledButton.tonal(
+              style: FilledButton.styleFrom(
+                backgroundColor: theme.colorScheme.errorContainer,
+                foregroundColor: theme.colorScheme.onErrorContainer,
               ),
-              TextButton(
-                style: TextButton.styleFrom(foregroundColor: Colors.red),
-                onPressed: () async {
-                  final messenger = ScaffoldMessenger.of(context);
-                  Navigator.of(dialogContext).pop();
-                  // Clear every persisted preference. Sessions, recordings,
-                  // voice memos and downloaded map tiles live outside of
-                  // SharedPreferences and are intentionally untouched.
-                  final prefs = await SharedPreferences.getInstance();
-                  await prefs.clear();
-                  messenger.showSnackBar(
-                    SnackBar(content: Text(l10n.settingsResetAllDone)),
-                  );
-                  // On Android we close the app so the next launch boots
-                  // with the freshly-reset defaults applied to every
-                  // provider. Other platforms leave the app running and
-                  // rely on the user to relaunch manually.
-                  await Future<void>.delayed(const Duration(milliseconds: 800));
-                  await SystemNavigator.pop();
-                },
-                child: Text(l10n.confirm),
-              ),
-            ],
-          ),
+              onPressed: () async {
+                final messenger = ScaffoldMessenger.of(context);
+                Navigator.of(dialogContext).pop();
+                // Clear every persisted preference. Sessions, recordings,
+                // voice memos and downloaded map tiles live outside of
+                // SharedPreferences and are intentionally untouched.
+                final prefs = await SharedPreferences.getInstance();
+                await prefs.clear();
+                messenger.showSnackBar(
+                  SnackBar(content: Text(l10n.settingsResetAllDone)),
+                );
+                // On Android we close the app so the next launch boots
+                // with the freshly-reset defaults applied to every
+                // provider. Other platforms leave the app running and
+                // rely on the user to relaunch manually.
+                await Future<void>.delayed(const Duration(milliseconds: 800));
+                await SystemNavigator.pop();
+              },
+              child: Text(l10n.confirm),
+            ),
+          ],
+        );
+      },
     );
   }
 
@@ -789,6 +802,7 @@ class SettingsScreen extends ConsumerWidget {
         final controller = TextEditingController();
         return StatefulBuilder(
           builder: (context, setState) {
+            final theme = Theme.of(context);
             final typed = controller.text.trim().toUpperCase() == 'DELETE';
             return AlertDialog(
               title: Text(l10n.settingsClearDataConfirmTitle),
@@ -813,7 +827,7 @@ class SettingsScreen extends ConsumerWidget {
                   onPressed: () => Navigator.of(context).pop(),
                   child: Text(l10n.cancel),
                 ),
-                TextButton(
+                FilledButton.tonal(
                   onPressed:
                       typed
                           ? () {
@@ -824,7 +838,10 @@ class SettingsScreen extends ConsumerWidget {
                             );
                           }
                           : null,
-                  style: TextButton.styleFrom(foregroundColor: Colors.red),
+                  style: FilledButton.styleFrom(
+                    backgroundColor: theme.colorScheme.errorContainer,
+                    foregroundColor: theme.colorScheme.onErrorContainer,
+                  ),
                   child: Text(l10n.confirm),
                 ),
               ],

--- a/lib/features/survey/survey_live_screen.dart
+++ b/lib/features/survey/survey_live_screen.dart
@@ -475,9 +475,9 @@ class _SurveyLiveScreenState extends ConsumerState<SurveyLiveScreen>
       SnackBar(
         content: Row(
           children: [
-            const Icon(
+            Icon(
               Icons.notifications_active_rounded,
-              color: Colors.white,
+              color: Theme.of(context).colorScheme.onInverseSurface,
               size: 18,
             ),
             const SizedBox(width: 8),

--- a/lib/features/survey/survey_setup_screen.dart
+++ b/lib/features/survey/survey_setup_screen.dart
@@ -24,6 +24,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:latlong2/latlong.dart';
 
+import '../../core/theme/app_semantic_colors.dart';
 import '../../shared/models/taxonomy_species.dart';
 import '../../shared/providers/settings_providers.dart';
 import '../../shared/widgets/app_help_bottom_sheet.dart';
@@ -524,18 +525,22 @@ class _DetailsStep extends StatelessWidget {
             // and only after the background-location permission has been
             // granted.
             Card(
-              color: const Color(0xFFD7F0DA),
+              color: AppSemanticColors.of(context).successContainer,
               child: Padding(
                 padding: const EdgeInsets.all(12),
                 child: Row(
                   children: [
-                    const Icon(Icons.lock_outline, color: Color(0xFF1B5E20)),
+                    Icon(
+                      Icons.lock_outline,
+                      color: AppSemanticColors.of(context).onSuccessContainer,
+                    ),
                     const SizedBox(width: 12),
                     Expanded(
                       child: Text(
                         l10n.surveyBackgroundGpsNotice,
                         style: theme.textTheme.bodySmall?.copyWith(
-                          color: const Color(0xFF1B5E20),
+                          color:
+                              AppSemanticColors.of(context).onSuccessContainer,
                         ),
                       ),
                     ),

--- a/lib/features/survey/widgets/survey_map_widget.dart
+++ b/lib/features/survey/widgets/survey_map_widget.dart
@@ -19,6 +19,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:latlong2/latlong.dart';
 
 import '../../../core/constants/app_constants.dart';
+import '../../../core/theme/app_semantic_colors.dart';
 import '../../../core/theme/score_colors.dart';
 import '../../../shared/models/gps_point.dart';
 import '../../../shared/providers/app_providers.dart';
@@ -318,7 +319,7 @@ class _SurveyMapWidgetState extends ConsumerState<SurveyMapWidget> {
           height: 28,
           child: Icon(
             Icons.flag_rounded,
-            color: Colors.green.shade700,
+            color: AppSemanticColors.of(context).success,
             size: 28,
           ),
         ),
@@ -575,9 +576,10 @@ class _SpeciesMarker extends ConsumerWidget {
     // confidence bucket (1.5 px for very-low up to 3.5 px for very-high) so
     // the strength of a detection survives complete loss of color vision —
     // a heavier ring still reads as "stronger" in monochrome.
+    final theme = Theme.of(context);
     final scoreColors = ScoreColors.of(context);
     final confidenceColor = scoreColors.forScore(confidence);
-    final borderColor = hasAudio ? confidenceColor : Colors.grey.shade500;
+    final borderColor = hasAudio ? confidenceColor : theme.colorScheme.outline;
     final bucket = ScoreColors.bucketIndexForScore(confidence);
     // 0 → 1.5, 1 → 2.0, 2 → 2.5, 3 → 3.0, 4 → 3.5
     final scoreBorderWidth = 1.5 + bucket * 0.5;
@@ -590,7 +592,7 @@ class _SpeciesMarker extends ConsumerWidget {
     // eliminate.
     if (useDot && !isHighlighted) {
       final dotSize = 10.0 + bucket * 2.0;
-      final fill = hasAudio ? confidenceColor : Colors.grey.shade500;
+      final fill = hasAudio ? confidenceColor : theme.colorScheme.outline;
       return Center(
         child: Container(
           width: dotSize,
@@ -599,12 +601,12 @@ class _SpeciesMarker extends ConsumerWidget {
             color: fill,
             shape: BoxShape.circle,
             border: Border.all(
-              color: Colors.white,
+              color: theme.colorScheme.surface,
               width: hasAudio ? scoreBorderWidth : 1.5,
             ),
             boxShadow: [
               BoxShadow(
-                color: Colors.black.withAlpha(60),
+                color: theme.colorScheme.shadow.withAlpha(60),
                 blurRadius: 2,
                 offset: const Offset(0, 1),
               ),
@@ -681,15 +683,15 @@ class _SpeciesMarker extends ConsumerWidget {
       decoration: BoxDecoration(
         shape: BoxShape.circle,
         border: Border.all(
-          color: isHighlighted ? Colors.blue : borderColor,
+          color: isHighlighted ? theme.colorScheme.primary : borderColor,
           width: isHighlighted ? 3 : (hasAudio ? scoreBorderWidth : 2),
         ),
         boxShadow: [
           BoxShadow(
             color:
                 isHighlighted
-                    ? Colors.blue.withAlpha(100)
-                    : Colors.black.withAlpha(50),
+                    ? theme.colorScheme.primary.withAlpha(100)
+                    : theme.colorScheme.shadow.withAlpha(50),
             blurRadius: isHighlighted ? 8 : 3,
             offset: const Offset(0, 1),
           ),
@@ -704,6 +706,7 @@ class _SpeciesMarker extends ConsumerWidget {
       // grey-plumaged bird could otherwise be mistaken for an audio marker
       // whose colored border just happens to be subtle.
       return _withConfirmedBadge(
+        context,
         Opacity(opacity: 0.6, child: avatar),
         size: size,
       );
@@ -719,6 +722,7 @@ class _SpeciesMarker extends ConsumerWidget {
     final badgeOffset = badgeSize * 0.25;
 
     return _withConfirmedBadge(
+      context,
       SizedBox(
         width: size + badgeOffset,
         height: size + badgeOffset,
@@ -737,10 +741,13 @@ class _SpeciesMarker extends ConsumerWidget {
                 decoration: BoxDecoration(
                   color: badgeColor,
                   shape: BoxShape.circle,
-                  border: Border.all(color: Colors.white, width: 1.5),
+                  border: Border.all(
+                    color: theme.colorScheme.surface,
+                    width: 1.5,
+                  ),
                   boxShadow: [
                     BoxShadow(
-                      color: Colors.black.withAlpha(80),
+                      color: theme.colorScheme.shadow.withAlpha(80),
                       blurRadius: 3,
                       offset: const Offset(0, 1),
                     ),
@@ -749,7 +756,7 @@ class _SpeciesMarker extends ConsumerWidget {
                 child: Icon(
                   Icons.play_arrow_rounded,
                   size: badgeSize * 0.85,
-                  color: Colors.white,
+                  color: theme.colorScheme.onPrimary,
                 ),
               ),
             ),
@@ -766,8 +773,14 @@ class _SpeciesMarker extends ConsumerWidget {
   /// collide. Returns [child] unchanged when the marker is not
   /// confirmed so we don't introduce a layout overhead for the common
   /// case.
-  Widget _withConfirmedBadge(Widget child, {required double size}) {
+  Widget _withConfirmedBadge(
+    BuildContext context,
+    Widget child, {
+    required double size,
+  }) {
     if (!isConfirmed) return child;
+    final theme = Theme.of(context);
+    final semanticColors = AppSemanticColors.of(context);
     final badgeSize = (size * 0.45).clamp(12.0, 18.0);
     final pad = badgeSize * 0.25;
     return SizedBox(
@@ -785,12 +798,15 @@ class _SpeciesMarker extends ConsumerWidget {
               width: badgeSize,
               height: badgeSize,
               decoration: BoxDecoration(
-                color: Colors.green.shade600,
+                color: semanticColors.success,
                 shape: BoxShape.circle,
-                border: Border.all(color: Colors.white, width: 1.5),
+                border: Border.all(
+                  color: theme.colorScheme.surface,
+                  width: 1.5,
+                ),
                 boxShadow: [
                   BoxShadow(
-                    color: Colors.black.withAlpha(80),
+                    color: theme.colorScheme.shadow.withAlpha(80),
                     blurRadius: 3,
                     offset: const Offset(0, 1),
                   ),
@@ -799,7 +815,7 @@ class _SpeciesMarker extends ConsumerWidget {
               child: Icon(
                 Icons.check_rounded,
                 size: badgeSize * 0.85,
-                color: Colors.white,
+                color: semanticColors.onSuccess,
               ),
             ),
           ),
@@ -834,10 +850,10 @@ class _ClusterBubble extends StatelessWidget {
       decoration: BoxDecoration(
         color: theme.colorScheme.primary,
         shape: BoxShape.circle,
-        border: Border.all(color: Colors.white, width: 2),
+        border: Border.all(color: theme.colorScheme.surface, width: 2),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withAlpha(70),
+            color: theme.colorScheme.shadow.withAlpha(70),
             blurRadius: 4,
             offset: const Offset(0, 2),
           ),

--- a/lib/features/survey/widgets/survey_stats_bar.dart
+++ b/lib/features/survey/widgets/survey_stats_bar.dart
@@ -10,7 +10,10 @@
 import 'package:flutter/material.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
+import '../../../core/theme/app_semantic_colors.dart';
 import '../../../shared/widgets/stat_chip.dart';
+
+enum _AudioQuality { bad, marginal, good }
 
 /// Compact statistics bar for an active survey.
 class SurveyStatsBar extends StatelessWidget {
@@ -50,23 +53,30 @@ class SurveyStatsBar extends StatelessWidget {
     //   green  = good ambient signal (typical birdsong environment)
     //   amber  = marginal (very quiet or moderately loud)
     //   red    = bad (silence / no signal, or clipping / wind noise)
-    final Color levelColor;
+    final semanticColors = AppSemanticColors.of(context);
+    final _AudioQuality quality;
     if (audioLevel < 0.0005) {
       // Silence or mic not working.
-      levelColor = Colors.red;
+      quality = _AudioQuality.bad;
     } else if (peakLevel > 0.95) {
       // Clipping — wind, handling noise, or mic overload.
-      levelColor = Colors.red;
+      quality = _AudioQuality.bad;
     } else if (audioLevel > 0.15) {
       // Very loud sustained noise (wind, traffic).
-      levelColor = Colors.red;
+      quality = _AudioQuality.bad;
     } else if (audioLevel < 0.001 || audioLevel > 0.08) {
       // Marginal: too quiet or somewhat loud.
-      levelColor = Colors.amber;
+      quality = _AudioQuality.marginal;
     } else {
       // Good range for birdsong detection (RMS ~0.001–0.08).
-      levelColor = Colors.green;
+      quality = _AudioQuality.good;
     }
+
+    final levelColor = switch (quality) {
+      _AudioQuality.bad => theme.colorScheme.error,
+      _AudioQuality.marginal => theme.colorScheme.tertiary,
+      _AudioQuality.good => semanticColors.success,
+    };
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -77,7 +87,12 @@ class SurveyStatsBar extends StatelessWidget {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: [
-          _AudioLevelChip(level: audioLevel, color: levelColor, style: style),
+          _AudioLevelChip(
+            level: audioLevel,
+            quality: quality,
+            color: levelColor,
+            style: style,
+          ),
           StatChip(
             icon: Icons.straighten,
             value: _formatDistance(distanceMeters),
@@ -114,11 +129,13 @@ class SurveyStatsBar extends StatelessWidget {
 class _AudioLevelChip extends StatelessWidget {
   const _AudioLevelChip({
     required this.level,
+    required this.quality,
     required this.color,
     this.style,
   });
 
   final double level;
+  final _AudioQuality quality;
   final Color color;
   final TextStyle? style;
 
@@ -126,9 +143,9 @@ class _AudioLevelChip extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final int filledBars;
-    if (color == Colors.green) {
+    if (quality == _AudioQuality.good) {
       filledBars = 3;
-    } else if (color == Colors.amber) {
+    } else if (quality == _AudioQuality.marginal) {
       filledBars = 2;
     } else {
       filledBars = 1;

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -64,6 +64,8 @@
   "settingsThemeDark": "Dunkel",
   "settingsThemeLight": "Hell",
   "settingsThemeSystem": "System",
+  "settingsDynamicColor": "Dynamische Farben",
+  "settingsDynamicColorDescription": "Farbpalette Ihres Android-Geräts verwenden, wenn verfügbar. Hat auf iPhone und iPad keine Wirkung.",
   "settingsResetOnboarding": "Onboarding zurücksetzen",
   "settingsClearData": "Alle Daten löschen",
   "settingsClearDataConfirmTitle": "Alle Daten löschen?",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -256,6 +256,14 @@
   "@settingsThemeSystem": {
     "description": "System theme option"
   },
+  "settingsDynamicColor": "Dynamic Color",
+  "@settingsDynamicColor": {
+    "description": "Dynamic color toggle label"
+  },
+  "settingsDynamicColorDescription": "Use your Android device's color palette when available. No effect on iPhone or iPad.",
+  "@settingsDynamicColorDescription": {
+    "description": "Dynamic color toggle description"
+  },
   "settingsResetOnboarding": "Reset Onboarding",
   "@settingsResetOnboarding": {
     "description": "Reset onboarding setting"

--- a/lib/shared/providers/app_providers.dart
+++ b/lib/shared/providers/app_providers.dart
@@ -8,14 +8,16 @@ import '../../core/constants/app_constants.dart';
 ///
 /// Must be overridden in [ProviderScope] at app startup.
 final sharedPreferencesProvider = Provider<SharedPreferences>(
-  (ref) => throw UnimplementedError(
-    'sharedPreferencesProvider must be overridden with a real instance',
-  ),
+  (ref) =>
+      throw UnimplementedError(
+        'sharedPreferencesProvider must be overridden with a real instance',
+      ),
 );
 
 /// Provider for the current [ThemeMode].
-final themeModeProvider =
-    StateNotifierProvider<ThemeModeNotifier, ThemeMode>((ref) {
+final themeModeProvider = StateNotifierProvider<ThemeModeNotifier, ThemeMode>((
+  ref,
+) {
   final prefs = ref.watch(sharedPreferencesProvider);
   return ThemeModeNotifier(prefs);
 });
@@ -39,6 +41,31 @@ class ThemeModeNotifier extends StateNotifier<ThemeMode> {
   Future<void> setThemeMode(ThemeMode mode) async {
     state = mode;
     await _prefs.setString(PrefKeys.themeMode, mode.name);
+  }
+}
+
+/// Whether to use the device's Android dynamic color palette.
+///
+/// Defaults to `false` so existing users keep the brand blue theme.
+/// On platforms that don't support dynamic color (e.g. iOS), this
+/// setting has no effect — the brand theme is always used as fallback.
+final dynamicColorProvider = StateNotifierProvider<DynamicColorNotifier, bool>((
+  ref,
+) {
+  final prefs = ref.watch(sharedPreferencesProvider);
+  return DynamicColorNotifier(prefs);
+});
+
+/// Notifier for the dynamic color toggle backed by [SharedPreferences].
+class DynamicColorNotifier extends StateNotifier<bool> {
+  DynamicColorNotifier(this._prefs)
+    : super(_prefs.getBool(PrefKeys.dynamicColor) ?? false);
+
+  final SharedPreferences _prefs;
+
+  Future<void> set(bool value) async {
+    state = value;
+    await _prefs.setBool(PrefKeys.dynamicColor, value);
   }
 }
 
@@ -74,14 +101,14 @@ class LocaleNotifier extends StateNotifier<Locale?> {
 /// Provider tracking whether onboarding has been completed.
 final onboardingCompleteProvider =
     StateNotifierProvider<OnboardingNotifier, bool>((ref) {
-  final prefs = ref.watch(sharedPreferencesProvider);
-  return OnboardingNotifier(prefs);
-});
+      final prefs = ref.watch(sharedPreferencesProvider);
+      return OnboardingNotifier(prefs);
+    });
 
 /// Notifier for onboarding completion state.
 class OnboardingNotifier extends StateNotifier<bool> {
   OnboardingNotifier(this._prefs)
-      : super(_prefs.getBool(PrefKeys.onboardingComplete) ?? false);
+    : super(_prefs.getBool(PrefKeys.onboardingComplete) ?? false);
 
   final SharedPreferences _prefs;
 
@@ -107,7 +134,7 @@ final termsAcceptedProvider = StateNotifierProvider<TermsNotifier, bool>((ref) {
 /// Notifier for terms acceptance state.
 class TermsNotifier extends StateNotifier<bool> {
   TermsNotifier(this._prefs)
-      : super(_prefs.getBool(PrefKeys.termsAccepted) ?? false);
+    : super(_prefs.getBool(PrefKeys.termsAccepted) ?? false);
 
   final SharedPreferences _prefs;
 

--- a/lib/shared/utils/session_type_visuals.dart
+++ b/lib/shared/utils/session_type_visuals.dart
@@ -6,24 +6,36 @@
 // and each is shown with a distinct icon throughout the UI: the home menu,
 // the help screen, the session library, the session review header, etc.
 //
-// To make modes instantly recognizable at a glance we also give each mode
-// a unique accent color that we apply to the *icon foreground* only (tile
-// backgrounds are intentionally left untouched so the visual rhythm of
-// list / grid surfaces stays calm).
-//
-// The colors are chosen to be:
-//   - clearly distinguishable on both light and dark themes,
-//   - accessible (sufficient contrast on neutral surfaces),
-//   - thematically meaningful (red = recording, blue = pinned point,
-//     green = movement / route, amber = file / archive).
+// To keep mode visuals recognizable under both the brand theme and dynamic
+// color, each mode starts from a stable base hue (red, blue, green, orange)
+// and is then harmonized with the active theme's primary color. This keeps
+// the four modes visually distinct without fighting the current palette.
 //
 // Centralizing the mapping here avoids drift between the home screen,
-// help screen, and history list views.
+// help screen, and history views.
 // =============================================================================
 
 import 'package:flutter/material.dart';
 
+import '../../core/theme/app_semantic_colors.dart';
+import '../../core/theme/app_theme.dart';
 import '../../features/live/live_session.dart';
+
+/// Theme-derived palette for a specific [SessionType].
+@immutable
+class SessionTypePalette {
+  const SessionTypePalette({
+    required this.accent,
+    required this.onAccent,
+    required this.container,
+    required this.onContainer,
+  });
+
+  final Color accent;
+  final Color onAccent;
+  final Color container;
+  final Color onContainer;
+}
 
 /// Returns the icon used to represent the given [SessionType] across the
 /// app (home menu, help, session library, review header, etc.).
@@ -40,24 +52,61 @@ IconData sessionTypeIcon(SessionType type) {
   }
 }
 
-/// Accent color used for the *icon foreground* of the given [SessionType].
-///
-/// Tile backgrounds are deliberately not colored — only the glyph itself
-/// is tinted so modes are recognizable at a glance without overwhelming
-/// the surrounding layout.
-Color sessionTypeIconColor(SessionType type) {
+/// Theme-derived colors for the given [SessionType].
+SessionTypePalette sessionTypePalette(ThemeData theme, SessionType type) {
+  final colorScheme = theme.colorScheme;
+  final semantic = AppSemanticColors.fromTheme(theme);
+  final accent = _accentForType(semantic, type);
+  final onAccent =
+      isBrandThemeColorScheme(colorScheme)
+          ? Colors.white
+          : (ThemeData.estimateBrightnessForColor(accent) == Brightness.dark
+              ? Colors.white
+              : Colors.black);
+  final container =
+      isBrandThemeColorScheme(colorScheme)
+          ? accent.withAlpha(40)
+          : Color.alphaBlend(
+            accent.withAlpha(theme.brightness == Brightness.dark ? 32 : 14),
+            colorScheme.surfaceContainerHigh,
+          );
+
+  return SessionTypePalette(
+    accent: accent,
+    onAccent: onAccent,
+    container: container,
+    onContainer: colorScheme.onSurface,
+  );
+}
+
+bool isBrandThemeColorScheme(ColorScheme colorScheme) {
+  return (colorScheme.primary == AppTheme.brandPrimary &&
+          colorScheme.primaryContainer == AppTheme.brandPrimaryContainer) ||
+      (colorScheme.primary == AppTheme.brandPrimaryLight &&
+          colorScheme.primaryContainer == AppTheme.brandPrimaryContainerDark);
+}
+
+Color _accentForType(AppSemanticColors colors, SessionType type) {
   switch (type) {
-    // Red — evokes a "record" indicator: live, real-time microphone session.
     case SessionType.live:
-      return const Color(0xFFE53935);
-    // Blue — a fixed pin / stationary observation.
+      return colors.sessionLive;
     case SessionType.pointCount:
-      return const Color(0xFF1E88E5);
-    // Green — movement along a route / transect.
+      return colors.sessionPointCount;
     case SessionType.survey:
-      return const Color(0xFF43A047);
-    // Amber — an archived audio file being analyzed offline.
+      return colors.sessionSurvey;
     case SessionType.fileUpload:
-      return const Color(0xFFFB8C00);
+      return colors.sessionFileAnalysis;
   }
 }
+
+Color sessionTypeAccentColor(ThemeData theme, SessionType type) =>
+    sessionTypePalette(theme, type).accent;
+
+Color sessionTypeOnAccentColor(ThemeData theme, SessionType type) =>
+    sessionTypePalette(theme, type).onAccent;
+
+Color sessionTypeContainerColor(ThemeData theme, SessionType type) =>
+    sessionTypePalette(theme, type).container;
+
+Color sessionTypeOnContainerColor(ThemeData theme, SessionType type) =>
+    sessionTypePalette(theme, type).onContainer;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: birdnet_live
 description: "Real-time bird species identification using on-device ONNX inference"
 publish_to: 'none'
-version: 0.14.2+147
+version: 0.14.3+148
 
 environment:
   sdk: ^3.7.0
@@ -60,6 +60,9 @@ dependencies:
 
   # Icons
   material_design_icons_flutter: ^7.0.7296
+
+  # Dynamic theming
+  dynamic_color: ^1.7.0
 
   # Network & Images
   http: ^1.2.2


### PR DESCRIPTION
Introduce a toggle for Dynamic Color (Material You) in settings (see issue #56), allowing users to opt into their Android device's color palette. Update the app to route semantic UI colors through the AppSemanticColors extension for improved visual consistency across themes. Bump version to 0.14.3.