### PR TITLE
Disable Flutter Impeller on Android to prevent crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.9] - 2026-05-20
+
+### Fixed
+
+- Disabled Flutter Impeller on Android so devices affected by rare Adreno Vulkan driver crashes during offscreen image cleanup fall back to the Skia renderer.
+
 ## [0.14.8] - 2026-05-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
   <img src="https://img.shields.io/badge/flutter-%3E%3D3.0-blue.svg" alt="Flutter">
   <img src="https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Windows-green.svg" alt="Platforms">
-  <img src="https://img.shields.io/badge/version-0.14.8-orange.svg" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.14.9-orange.svg" alt="Version">
   <img src="https://img.shields.io/badge/species-5%2C250-brightgreen.svg" alt="Species: 5,250">
 </p>
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -40,6 +40,11 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <!-- Work around rare Adreno Vulkan driver crashes in Flutter Impeller
+             during offscreen image cleanup by using Skia on Android. -->
+        <meta-data
+            android:name="io.flutter.embedding.android.EnableImpeller"
+            android:value="false" />
         <!-- Notification small-icon for the survey foreground service.
              Referenced by NotificationIcon(metaDataName: ...) in
              lib/features/survey/survey_notification.dart. -->

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: birdnet_live
 description: "Real-time bird species identification using on-device ONNX inference"
 publish_to: 'none'
-version: 0.14.8+153
+version: 0.14.9+154
 
 environment:
   sdk: ^3.7.0


### PR DESCRIPTION
Disable Flutter Impeller on Android to address rare crashes caused by the Adreno Vulkan driver during offscreen image cleanup, ensuring a fallback to the Skia renderer. Update version to 0.14.9.