### PR TITLE
Disable LFS for checkout in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          lfs: true
+          lfs: false
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,20 +15,6 @@ jobs:
         with:
           lfs: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install species-bundle dependencies
-        run: pip install -r tools/requirements-species-bundle.txt
-
-      - name: Download BirdNET taxonomy export
-        run: python tools/download_taxonomy_json.py
-
-      - name: Build species bundle assets
-        run: python tools/build_species_bundle.py
-
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
@@ -55,6 +41,20 @@ jobs:
 
       - name: Test
         run: flutter test
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install species-bundle dependencies
+        run: pip install -r tools/requirements-species-bundle.txt
+
+      - name: Download BirdNET taxonomy export
+        run: python tools/download_taxonomy_json.py
+
+      - name: Build species bundle assets
+        run: python tools/build_species_bundle.py
 
       - name: Check signing secrets availability
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,29 +7,8 @@ on:
 permissions:
   contents: write
 jobs:
-  flutter_test:
-    name: Run Flutter Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          lfs: true
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - uses: subosito/flutter-action@v2 #https://github.com/subosito/flutter-action
-        with:
-          flutter-version: '3.41.9'
-          channel: stable
-      - run: flutter --version
-      - run: flutter pub get
-      - run: flutter gen-l10n
-      - run: flutter analyze --no-fatal-infos
-      - run: flutter test
-
-  prepare_assets:
-    name: Prepare Species Assets
+  build_android:
+    name: Test And Build Android APK
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -50,41 +29,6 @@ jobs:
       - name: Build species bundle assets
         run: python tools/build_species_bundle.py
 
-      - name: Upload prepared species assets
-        uses: actions/upload-artifact@v4
-        with:
-          name: prepared-species-assets
-          path: |
-            assets/species_data/
-            assets/species_images/
-            assets/models/taxonomy.csv
-          if-no-files-found: error
-
-  build_android:
-    name: Build Android APK
-    runs-on: ubuntu-latest
-    needs: [flutter_test, prepare_assets]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          lfs: true
-
-      - name: Download prepared species assets
-        uses: actions/download-artifact@v4
-        with:
-          name: prepared-species-assets
-          path: prepared-assets
-
-      - name: Restore prepared assets into workspace
-        shell: bash
-        run: |
-          rm -rf assets/species_data assets/species_images
-          mkdir -p assets/models
-          cp -R prepared-assets/species_data assets/species_data
-          cp -R prepared-assets/species_images assets/species_images
-          cp prepared-assets/models/taxonomy.csv assets/models/taxonomy.csv
-
-
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
@@ -97,11 +41,20 @@ jobs:
           flutter-version: '3.41.9'
           channel: stable
 
+      - name: Show Flutter version
+        run: flutter --version
+
       - name: Install Dart and Flutter packages
         run: flutter pub get
 
       - name: Generate localization files
         run: flutter gen-l10n
+
+      - name: Analyze
+        run: flutter analyze --no-fatal-infos
+
+      - name: Test
+        run: flutter test
 
       - name: Check signing secrets availability
         shell: bash


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows, mainly simplifying and consolidating the build and test steps for the release process. The main improvements are the removal of intermediate asset preparation/upload steps and merging of testing and building into a single job, which should streamline the release pipeline.

**Workflow simplification and consolidation:**

* Removed the separate `flutter_test` and `prepare_assets` jobs, and merged their steps into a single `build_android` job, reducing complexity and improving maintainability.
* Eliminated the upload/download of prepared species assets as artifacts by running all necessary asset preparation and build steps within the same job, which simplifies the workflow and avoids unnecessary file transfers.

**Build and test improvements:**

* Added explicit steps in the unified job to show the Flutter version, run code analysis, and execute tests, ensuring code quality checks are always performed as part of the build.

**Other workflow tweaks:**

* Changed the `lfs` (Large File Storage) setting in the `ci.yml` workflow from `true` to `false`, potentially speeding up checkouts if LFS is not required.