### PR TITLE
Fallback to English for unsupported locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In Session Review, the highest-confidence sort now also orders detections inside each species, preferring detections with playable audio clips before clipless detections.
 - Raised the default confidence threshold setting from 25% to 35%.
 
+### Fixed
+
+- Unsupported device languages now fall back to English instead of the first generated locale.
+
 ## [0.15.3] - 2026-05-22
 
 ### Added

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -10,6 +10,29 @@ import 'features/announcements/accessibility_default_applier.dart';
 import 'features/onboarding/onboarding_screen.dart';
 import 'features/home/home_screen.dart';
 
+/// Resolve the UI locale from the platform/app preference list.
+///
+/// Flutter's generated locale list is alphabetized, so relying on the default
+/// fallback can land unsupported languages on Czech because `cs` is first.
+/// Prefer an exact language match from the user's locale list, otherwise fall
+/// back to English explicitly.
+Locale resolveAppLocale(
+  List<Locale>? preferredLocales,
+  Iterable<Locale> supportedLocales,
+) {
+  final supported = supportedLocales.toList();
+  for (final preferred in preferredLocales ?? const <Locale>[]) {
+    for (final candidate in supported) {
+      if (candidate.languageCode == preferred.languageCode) return candidate;
+    }
+  }
+
+  return supported.firstWhere(
+    (locale) => locale.languageCode == 'en',
+    orElse: () => supported.first,
+  );
+}
+
 /// Root application widget.
 ///
 /// Configures theme, localization, and the initial route based on
@@ -56,6 +79,12 @@ class App extends ConsumerWidget {
             GlobalCupertinoLocalizations.delegate,
           ],
           supportedLocales: AppLocalizations.supportedLocales,
+          localeListResolutionCallback: resolveAppLocale,
+          localeResolutionCallback:
+              (locale, supportedLocales) => resolveAppLocale(
+                locale == null ? null : <Locale>[locale],
+                supportedLocales,
+              ),
 
           // Initial screen based on app state
           home: const AnnouncementsAccessibilityDefaultApplier(

--- a/test/app_locale_resolution_test.dart
+++ b/test/app_locale_resolution_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:birdnet_live/app.dart';
+import 'package:birdnet_live/l10n/app_localizations.dart';
+
+void main() {
+  group('resolveAppLocale', () {
+    test('falls back to English for an unsupported device language', () {
+      final resolved = resolveAppLocale(const [
+        Locale('ca'),
+      ], AppLocalizations.supportedLocales);
+
+      expect(resolved, const Locale('en'));
+    });
+
+    test('uses a later preferred locale when it is supported', () {
+      final resolved = resolveAppLocale(const [
+        Locale('ca'),
+        Locale('es'),
+      ], AppLocalizations.supportedLocales);
+
+      expect(resolved, const Locale('es'));
+    });
+
+    test('uses English when no preferred locales are available', () {
+      final resolved = resolveAppLocale(
+        null,
+        AppLocalizations.supportedLocales,
+      );
+
+      expect(resolved, const Locale('en'));
+    });
+  });
+}


### PR DESCRIPTION
Implement a mechanism to ensure that unsupported device languages fall back to English instead of defaulting to the first generated locale. This change includes a new locale resolution function and corresponding tests to verify the behavior.