### PR TITLE
fix (tools): use ASCII arrow instead of utf -8

### DIFF
--- a/tools/build_species_bundle.py
+++ b/tools/build_species_bundle.py
@@ -272,7 +272,7 @@ def extract_descriptions(
             f.write(json_bytes)
         raw_kb = len(json_bytes) / 1024
         gz_kb = gz_path.stat().st_size / 1024
-        print(f"  {locale}: {len(descs)} descriptions, {raw_kb:.0f} KB raw → {gz_kb:.0f} KB gzip")
+        print(f"  {locale}: {len(descs)} descriptions, {raw_kb:.0f} KB raw -> {gz_kb:.0f} KB gzip")
 
     return coverage
 


### PR DESCRIPTION
windows console can't print "→" resulting in an error