### PR TITLE
Allow export of audio as WAV format and update settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,14 @@ This file is for coding agents working in this repository.
 - Run flutter analyze (and flutter test when relevant) before committing.
 - Keep release commits focused and use a conventional commit message.
 
+## Search for All Affected Call Sites Before Implementing
+
+When a feature touches a shared function, setting, or data path, grep the full codebase for every place that function is called or that path is used — not just the location described in the request. Implement the change at **all** affected locations in the same pass.
+
+- Before writing code, grep for the function name, setting key, and provider name across `lib/`.
+- Check every call site and every parallel code path that handles the same data.
+- If multiple screens, services, or widgets do "the same thing" independently, update all of them.
+
 ## Git Workflow
 
 - Use conventional one-line commit messages, for example:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- allow audio export as wav independent from the recording format for iNat interoperability
+- sort species chips in session card alphabetically and update top species logic
+
 ## [0.17.16] - 2026-06-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- allow audio export as wav independent from the recording format for iNat interoperability
-- sort species chips in session card alphabetically and update top species logic
+## [0.17.17] - 2026-06-25
+
+### Added
+
+- Allow audio export as WAV independent from the recording format for iNat interoperability
+
+### Changed
+
+- Sort species chips in session card alphabetically and update top species logic
 
 ## [0.17.16] - 2026-06-24
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
    <img src="https://img.shields.io/badge/flutter-%3E%3D3.27-blue.svg" alt="Flutter >=3.27">
   <img src="https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Windows-green.svg" alt="Platforms">
-  <img src="https://img.shields.io/badge/version-0.17.16-orange.svg" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.17.17-orange.svg" alt="Version">
   <img src="https://img.shields.io/badge/species-5%2C250-brightgreen.svg" alt="Species: 5,250">
 </p>
 

--- a/docs/index.cs.md
+++ b/docs/index.cs.md
@@ -5,7 +5,7 @@
 BirdNET Live je aplikace ve Flutteru určená terénním výzkumníkům, ochráncům přírody a pozorovatelům ptáků, kteří v terénu potřebují spolehlivé akustické důkazy. Audio klasifikátor BirdNET+ i geomodel běží přímo ve vašem zařízení, takže identifikace druhů funguje po instalaci zcela offline.
 
 <p align="center">
-  <img src="https://img.shields.io/badge/latest-v0.17.16-orange.svg" alt="Latest release: v0.17.16">
+  <img src="https://img.shields.io/badge/latest-v0.17.17-orange.svg" alt="Latest release: v0.17.17">
   <img src="https://img.shields.io/badge/species-5%2C250-brightgreen.svg" alt="Species: 5,250">
   <img src="https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Windows-green.svg" alt="Platforms">
 </p>

--- a/docs/index.de.md
+++ b/docs/index.de.md
@@ -5,7 +5,7 @@
 BirdNET Live ist eine Flutter-App für Feldforschende, im Naturschutz Tätige und Vogelbegeisterte, die im Feld auf verlässliche akustische Nachweise angewiesen sind. Der BirdNET+ Audio-Klassifikator und das Geo-Modell laufen direkt auf Ihrem Gerät, sodass die Artbestimmung nach der Installation vollständig offline funktioniert.
 
 <p align="center">
-  <img src="https://img.shields.io/badge/latest-v0.17.16-orange.svg" alt="Latest release: v0.17.16">
+  <img src="https://img.shields.io/badge/latest-v0.17.17-orange.svg" alt="Latest release: v0.17.17">
   <img src="https://img.shields.io/badge/species-5%2C250-brightgreen.svg" alt="Species: 5,250">
   <img src="https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Windows-green.svg" alt="Platforms">
 </p>

--- a/docs/index.es.md
+++ b/docs/index.es.md
@@ -5,7 +5,7 @@
 BirdNET Live es una app de Flutter creada para investigadores de campo, conservacionistas y observadores de aves que necesitan evidencia acústica fiable sobre el terreno. Ejecuta el clasificador de audio y el geomodelo de BirdNET+ directamente en tu dispositivo, de modo que la identificación de especies funciona completamente sin conexión una vez instalada.
 
 <p align="center">
-  <img src="https://img.shields.io/badge/latest-v0.17.16-orange.svg" alt="Latest release: v0.17.16">
+  <img src="https://img.shields.io/badge/latest-v0.17.17-orange.svg" alt="Latest release: v0.17.17">
   <img src="https://img.shields.io/badge/species-5%2C250-brightgreen.svg" alt="Species: 5,250">
   <img src="https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Windows-green.svg" alt="Platforms">
 </p>

--- a/docs/index.fr.md
+++ b/docs/index.fr.md
@@ -5,7 +5,7 @@
 BirdNET Live est une application Flutter conçue pour les chercheurs de terrain, les naturalistes et les ornithologues amateurs qui ont besoin de preuves acoustiques fiables sur le terrain. Elle exécute le classifieur audio BirdNET+ et le géo-modèle directement sur votre appareil : l'identification des espèces fonctionne donc entièrement hors ligne une fois l'application installée.
 
 <p align="center">
-  <img src="https://img.shields.io/badge/latest-v0.17.16-orange.svg" alt="Latest release: v0.17.16">
+  <img src="https://img.shields.io/badge/latest-v0.17.17-orange.svg" alt="Latest release: v0.17.17">
   <img src="https://img.shields.io/badge/species-5%2C250-brightgreen.svg" alt="Species: 5,250">
   <img src="https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Windows-green.svg" alt="Platforms">
 </p>

--- a/docs/index.it.md
+++ b/docs/index.it.md
@@ -5,7 +5,7 @@
 BirdNET Live è un'app Flutter pensata per chi fa ricerca sul campo, per chi si occupa di conservazione e per il birdwatching, e ha bisogno di prove acustiche affidabili sul campo. Esegue il classificatore audio BirdNET+ e il geo-modello direttamente sul dispositivo, quindi l'identificazione delle specie funziona completamente offline una volta installata.
 
 <p align="center">
-  <img src="https://img.shields.io/badge/latest-v0.17.16-orange.svg" alt="Latest release: v0.17.16">
+  <img src="https://img.shields.io/badge/latest-v0.17.17-orange.svg" alt="Latest release: v0.17.17">
   <img src="https://img.shields.io/badge/species-5%2C250-brightgreen.svg" alt="Species: 5,250">
   <img src="https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Windows-green.svg" alt="Platforms">
 </p>

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
 BirdNET Live is a Flutter app built for field researchers, conservationists, and birders who need dependable acoustic evidence in the field. It runs the BirdNET+ audio classifier and geo-model directly on your device, so species identification works fully offline once installed.
 
 <p align="center">
-  <img src="https://img.shields.io/badge/latest-v0.17.16-orange.svg" alt="Latest release: v0.17.16">
+  <img src="https://img.shields.io/badge/latest-v0.17.17-orange.svg" alt="Latest release: v0.17.17">
   <img src="https://img.shields.io/badge/species-5%2C250-brightgreen.svg" alt="Species: 5,250">
   <img src="https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Windows-green.svg" alt="Platforms">
 </p>

--- a/docs/index.pt.md
+++ b/docs/index.pt.md
@@ -5,7 +5,7 @@
 O BirdNET Live é um aplicativo Flutter desenvolvido para pesquisadores de campo, profissionais de conservação e observadores de aves que precisam de evidências acústicas confiáveis em campo. Ele executa o classificador de áudio BirdNET+ e o geomodelo diretamente no seu dispositivo, de modo que a identificação de espécies funciona totalmente offline depois de instalado.
 
 <p align="center">
-  <img src="https://img.shields.io/badge/latest-v0.17.16-orange.svg" alt="Latest release: v0.17.16">
+  <img src="https://img.shields.io/badge/latest-v0.17.17-orange.svg" alt="Latest release: v0.17.17">
   <img src="https://img.shields.io/badge/species-5%2C250-brightgreen.svg" alt="Species: 5,250">
   <img src="https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Windows-green.svg" alt="Platforms">
 </p>

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -112,6 +112,7 @@ abstract final class PrefKeys {
   static const String exportSelection = 'export_selection';
 
   static const String includeAudio = 'include_audio';
+  static const String shareAudioAsWav = 'share_audio_as_wav';
   static const String exportHtmlReport = 'export_html_report';
   static const String includeAppMetadata = 'include_app_metadata';
 

--- a/lib/features/history/services/detection_sharing_service.dart
+++ b/lib/features/history/services/detection_sharing_service.dart
@@ -47,6 +47,7 @@ import 'package:share_plus/share_plus.dart';
 import '../../live/live_session.dart';
 import '../../recording/audio_decoder.dart';
 import '../../recording/flac_encoder.dart';
+import '../../recording/wav_writer.dart';
 
 /// Share a single [detection] using the platform share sheet.
 ///
@@ -61,6 +62,7 @@ import '../../recording/flac_encoder.dart';
 Future<ShareResult> shareDetection(
   DetectionRecord detection, {
   LiveSession? session,
+  bool shareAudioAsWav = false,
 }) async {
   final body = _buildBody(detection);
   final subject = _buildSubject(detection);
@@ -69,7 +71,11 @@ Future<ShareResult> shareDetection(
   //    correct context padding at the moment of detection.
   final clipPath = detection.audioClipPath;
   if (clipPath != null && File(clipPath).existsSync()) {
-    final staged = await _stageClipForShare(File(clipPath), detection);
+    final staged = await _stageClipForShare(
+      File(clipPath),
+      detection,
+      shareAudioAsWav: shareAudioAsWav,
+    );
     return SharePlus.instance.share(
       ShareParams(files: [XFile(staged.path)], text: body, subject: subject),
     );
@@ -77,9 +83,13 @@ Future<ShareResult> shareDetection(
 
   // 2) Try to slice from the session's full recording. Both WAV and
   //    FLAC continuous recordings are supported; the slice ships in
-  //    the same container as the source.
+  //    the same container as the source (or WAV if shareAudioAsWav).
   if (session != null) {
-    final extracted = await _extractClipFromFullAudio(session, detection);
+    final extracted = await _extractClipFromFullAudio(
+      session,
+      detection,
+      shareAudioAsWav: shareAudioAsWav,
+    );
     if (extracted != null) {
       return SharePlus.instance.share(
         ShareParams(
@@ -99,16 +109,34 @@ Future<ShareResult> shareDetection(
 /// Copies [clip] into the temp dir under the export-style filename so the
 /// share sheet exposes a friendly name. Reuses an existing staged file when
 /// the names already match to avoid extra IO on repeat shares.
-Future<File> _stageClipForShare(File clip, DetectionRecord d) async {
-  final ext = p.extension(clip.path);
-  final name = _exportClipName(d, ext);
+Future<File> _stageClipForShare(
+  File clip,
+  DetectionRecord d, {
+  bool shareAudioAsWav = false,
+}) async {
+  final srcExt = p.extension(clip.path).toLowerCase();
+  final outExt =
+      (shareAudioAsWav && srcExt == '.flac') ? '.wav' : srcExt;
+  final name = _exportClipName(d, outExt);
   final tmp = await getTemporaryDirectory();
   final shareDir = Directory(p.join(tmp.path, 'shared_clips'));
   if (!shareDir.existsSync()) shareDir.createSync(recursive: true);
   final target = File(p.join(shareDir.path, name));
-  // Always overwrite: the source clip may have been re-encoded since
-  // the previous share and the cost is a single small file copy.
-  await clip.copy(target.path);
+
+  if (shareAudioAsWav && srcExt == '.flac') {
+    final decoded = await AudioDecoder.decodeFile(clip.path);
+    final floats = Float32List(decoded.samples.length);
+    for (var i = 0; i < decoded.samples.length; i++) {
+      floats[i] = decoded.samples[i] / 32768.0;
+    }
+    await WavWriter.writeFile(
+      filePath: target.path,
+      samples: floats,
+      sampleRate: decoded.sampleRate,
+    );
+  } else {
+    await clip.copy(target.path);
+  }
   return target;
 }
 
@@ -150,13 +178,15 @@ String _sanitizeFilename(String input) {
 @visibleForTesting
 Future<File?> extractClipFromFullAudio(
   LiveSession session,
-  DetectionRecord detection,
-) => _extractClipFromFullAudio(session, detection);
+  DetectionRecord detection, {
+  bool shareAudioAsWav = false,
+}) => _extractClipFromFullAudio(session, detection, shareAudioAsWav: shareAudioAsWav);
 
 Future<File?> _extractClipFromFullAudio(
   LiveSession session,
-  DetectionRecord detection,
-) async {
+  DetectionRecord detection, {
+  bool shareAudioAsWav = false,
+}) async {
   final fullPath = _resolveFullAudioPath(session.recordingPath);
   if (fullPath == null) return null;
   final src = File(fullPath);
@@ -179,10 +209,13 @@ Future<File?> _extractClipFromFullAudio(
   final ext = p.extension(fullPath).toLowerCase();
   if (ext != '.wav' && ext != '.flac') return null;
 
+  final outExt = (shareAudioAsWav && ext == '.flac') ? '.wav' : ext;
   final tmp = await getTemporaryDirectory();
   final shareDir = Directory(p.join(tmp.path, 'shared_clips'));
   if (!shareDir.existsSync()) shareDir.createSync(recursive: true);
-  final target = File(p.join(shareDir.path, _exportClipName(detection, ext)));
+  final target = File(
+    p.join(shareDir.path, _exportClipName(detection, outExt)),
+  );
 
   try {
     if (ext == '.wav') {
@@ -193,6 +226,14 @@ Future<File?> _extractClipFromFullAudio(
       );
       if (sliceBytes == null || sliceBytes.isEmpty) return null;
       await target.writeAsBytes(sliceBytes, flush: true);
+    } else if (shareAudioAsWav) {
+      final wrote = await _sliceFlacToWavFile(
+        src,
+        target,
+        startSec: startSec,
+        durationSec: clipDurationSec.toDouble(),
+      );
+      if (!wrote) return null;
     } else {
       final wrote = await _sliceFlacToFile(
         src,
@@ -334,6 +375,37 @@ Future<bool> _sliceFlacToFile(
     floats[i] = decoded.samples[i] / 32768.0;
   }
   await FlacEncoder.writeFile(
+    filePath: target.path,
+    samples: floats,
+    sampleRate: decoded.sampleRate,
+  );
+  return true;
+}
+
+/// Like [_sliceFlacToFile] but writes the decoded PCM as WAV instead of FLAC.
+Future<bool> _sliceFlacToWavFile(
+  File src,
+  File target, {
+  required double startSec,
+  required double durationSec,
+}) async {
+  const assumedRate = 32000;
+  final startSample = (startSec * assumedRate).floor();
+  final count = (durationSec * assumedRate).ceil();
+  if (count <= 0 || startSample < 0) return false;
+
+  final decoded = await AudioDecoder.decodeFlacRange(
+    src.path,
+    startSample: startSample,
+    count: count,
+  );
+  if (decoded.totalSamples == 0) return false;
+
+  final floats = Float32List(decoded.totalSamples);
+  for (var i = 0; i < decoded.totalSamples; i++) {
+    floats[i] = decoded.samples[i] / 32768.0;
+  }
+  await WavWriter.writeFile(
     filePath: target.path,
     samples: floats,
     sampleRate: decoded.sampleRate,

--- a/lib/features/history/session_export.dart
+++ b/lib/features/history/session_export.dart
@@ -39,10 +39,31 @@ import '../../shared/services/taxonomy_service.dart';
 import '../live/live_session.dart';
 import '../recording/audio_decoder.dart';
 import '../recording/native_audio_decoder.dart';
+import '../recording/wav_writer.dart';
 import 'html_report.dart';
 
 /// Upper frequency bound for Raven annotations (Nyquist of 32 kHz).
 const int _highFreqHz = 16000;
+
+/// Decodes a FLAC file and returns the bytes of an equivalent PCM WAV.
+/// Returns null if decoding fails (caller should fall back to original file).
+Future<Uint8List?> _flacToWavBytes(String flacPath) async {
+  try {
+    if (!await AudioDecoder.canDecodeDart(flacPath)) return null;
+    final decoded = await AudioDecoder.decodeFile(flacPath);
+    // DecodedAudio stores mono Int16; convert to Float32 for WavWriter.
+    final float = Float32List(decoded.samples.length);
+    for (var i = 0; i < decoded.samples.length; i++) {
+      float[i] = decoded.samples[i] / 32768.0;
+    }
+    return WavWriter.toBytes(
+      samples: float,
+      sampleRate: decoded.sampleRate,
+    );
+  } catch (_) {
+    return null;
+  }
+}
 
 /// Builds the `BirdNET_Live_…` export prefix from a session's start time,
 /// optional session number, and optional user-assigned name.
@@ -793,6 +814,7 @@ Future<String?> buildSessionExport(
   LiveSession session, {
   required Set<String> formats,
   required bool includeAudio,
+  bool shareAudioAsWav = false,
   TaxonomyService? taxonomy,
   String speciesLocale = 'en',
   int? clipContextSecondsOverride,
@@ -839,10 +861,15 @@ Future<String?> buildSessionExport(
   final hasAnyAudio = hasFullRecording || hasClips;
 
   // ── Build export clip names (sequential, 1-indexed, zero-padded) ────
-  final audioExt =
-      hasFullRecording
-          ? p.extension(audioPath)
-          : (hasClips ? p.extension(clipEntries.values.first.path) : '.flac');
+  String resolveExt(String originalExt) =>
+      (shareAudioAsWav && originalExt.toLowerCase() == '.flac')
+          ? '.wav'
+          : originalExt;
+  final audioExt = resolveExt(
+    hasFullRecording
+        ? p.extension(audioPath)
+        : (hasClips ? p.extension(clipEntries.values.first.path) : '.flac'),
+  );
   final audioFileName = '$prefix$audioExt';
 
   // Map detection index → export clip filename.
@@ -874,7 +901,7 @@ Future<String?> buildSessionExport(
     final file = File(path);
     if (!file.existsSync()) continue;
     final cycleName =
-        'aru_cycles/${prefix}_cycle_${cycle.index.toString().padLeft(3, '0')}${p.extension(path)}';
+        'aru_cycles/${prefix}_cycle_${cycle.index.toString().padLeft(3, '0')}${resolveExt(p.extension(path))}';
     aruCycleAudioEntries[cycle.index] = (file: file, name: cycleName);
   }
   final hasAruCycleAudio = aruCycleAudioEntries.isNotEmpty;
@@ -959,19 +986,25 @@ Future<String?> buildSessionExport(
 
   // Audio-only mode: the user unchecked every companion (no formats,
   // no HTML, no app metadata). For full-recording sessions we share the
-  // raw audio file as-is, renamed to the BirdNET_Live_… prefix so the
-  // receiving app shows a sensible filename.
+  // raw audio file (converted to WAV if requested), renamed to the
+  // BirdNET_Live_… prefix so the receiving app shows a sensible filename.
   if (!mustZip && includeAudio && hasFullRecording && !hasCompanion) {
     final dest = p.join(p.dirname(audioPath), audioFileName);
-    if (dest != audioPath) {
-      final destFile = File(dest);
-      if (await destFile.exists()) {
-        try {
-          await destFile.delete();
-        } catch (_) {}
-      }
-      await File(audioPath).copy(dest);
+    final destFile = File(dest);
+    if (await destFile.exists()) {
+      try {
+        await destFile.delete();
+      } catch (_) {}
     }
+    if (shareAudioAsWav &&
+        p.extension(audioPath).toLowerCase() == '.flac') {
+      final wavBytes = await _flacToWavBytes(audioPath);
+      if (wavBytes != null) {
+        await destFile.writeAsBytes(wavBytes);
+        return dest;
+      }
+    }
+    if (dest != audioPath) await File(audioPath).copy(dest);
     return dest;
   }
 
@@ -982,26 +1015,29 @@ Future<String?> buildSessionExport(
   if (mustZip) {
     final archive = Archive();
 
+    Future<Uint8List> audioBytes(String path) async {
+      if (shareAudioAsWav && p.extension(path).toLowerCase() == '.flac') {
+        return await _flacToWavBytes(path) ?? await File(path).readAsBytes();
+      }
+      return File(path).readAsBytes();
+    }
+
     if (includeAudio && hasAnyAudio) {
       if (hasFullRecording) {
-        final audioBytes = await File(audioPath).readAsBytes();
-        archive.addFile(
-          ArchiveFile(audioFileName, audioBytes.length, audioBytes),
-        );
+        final bytes = await audioBytes(audioPath);
+        archive.addFile(ArchiveFile(audioFileName, bytes.length, bytes));
       } else {
         for (final entry in clipExportNames.entries) {
-          final clipBytes = await clipEntries[entry.key]!.readAsBytes();
-          archive.addFile(
-            ArchiveFile(entry.value, clipBytes.length, clipBytes),
-          );
+          final bytes = await audioBytes(clipEntries[entry.key]!.path);
+          archive.addFile(ArchiveFile(entry.value, bytes.length, bytes));
         }
       }
     }
 
     if (includeAudio && hasAruCycleAudio) {
       for (final entry in aruCycleAudioEntries.values) {
-        final audioBytes = await entry.file.readAsBytes();
-        archive.addFile(ArchiveFile(entry.name, audioBytes.length, audioBytes));
+        final bytes = await audioBytes(entry.file.path);
+        archive.addFile(ArchiveFile(entry.name, bytes.length, bytes));
       }
     }
 
@@ -1278,6 +1314,7 @@ Future<String?> buildMultiSessionExport(
   List<LiveSession> sessions, {
   required Set<String> formats,
   required bool includeAudio,
+  bool shareAudioAsWav = false,
   TaxonomyService? taxonomy,
   String speciesLocale = 'en',
   int? clipContextSecondsOverride,
@@ -1301,6 +1338,7 @@ Future<String?> buildMultiSessionExport(
       session,
       formats: formats,
       includeAudio: includeAudio,
+      shareAudioAsWav: shareAudioAsWav,
       taxonomy: taxonomy,
       speciesLocale: speciesLocale,
       clipContextSecondsOverride: clipContextSecondsOverride,

--- a/lib/features/history/session_library_screen.dart
+++ b/lib/features/history/session_library_screen.dart
@@ -809,6 +809,7 @@ class _SessionLibraryScreenState extends ConsumerState<SessionLibraryScreen> {
   Future<void> _shareSession(LiveSession session) async {
     final exportFormats = ref.read(exportSelectionProvider);
     final includeAudio = ref.read(includeAudioProvider);
+    final shareAudioAsWav = ref.read(shareAudioAsWavProvider);
     final includeHtmlReport = ref.read(exportHtmlReportProvider);
     final includeAppMetadata = ref.read(includeAppMetadataProvider);
     final taxonomy = ref.read(taxonomyServiceProvider).value;
@@ -823,6 +824,7 @@ class _SessionLibraryScreenState extends ConsumerState<SessionLibraryScreen> {
       session,
       formats: exportFormats,
       includeAudio: includeAudio,
+      shareAudioAsWav: shareAudioAsWav,
       taxonomy: taxonomy,
       speciesLocale: speciesLocale,
       metadata: metadata,
@@ -901,6 +903,7 @@ class _SessionLibraryScreenState extends ConsumerState<SessionLibraryScreen> {
     try {
       final exportFormats = ref.read(exportSelectionProvider);
       final includeAudio = ref.read(includeAudioProvider);
+      final shareAudioAsWav = ref.read(shareAudioAsWavProvider);
       final includeHtmlReport = ref.read(exportHtmlReportProvider);
       final includeAppMetadata = ref.read(includeAppMetadataProvider);
       final taxonomy = ref.read(taxonomyServiceProvider).value;
@@ -912,6 +915,7 @@ class _SessionLibraryScreenState extends ConsumerState<SessionLibraryScreen> {
         selectedList,
         formats: exportFormats,
         includeAudio: includeAudio,
+        shareAudioAsWav: shareAudioAsWav,
         taxonomy: taxonomy,
         speciesLocale: speciesLocale,
         useAbsoluteSurveyTime: useAbsoluteSurveyTime,

--- a/lib/features/history/session_library_screen.dart
+++ b/lib/features/history/session_library_screen.dart
@@ -1116,29 +1116,37 @@ class _SessionTile extends ConsumerWidget {
                 Wrap(
                   spacing: 8,
                   runSpacing: 4,
-                  children:
-                      _topSpeciesSci(session).map((entry) {
+                  children: () {
                         final speciesLocale = ref.watch(
                           effectiveSpeciesLocaleProvider,
                         );
                         final taxonomy =
                             ref.watch(taxonomyServiceProvider).value;
-                        final displayName =
-                            taxonomy
-                                ?.lookup(entry.key)
-                                ?.commonNameForLocale(speciesLocale) ??
-                            entry.value;
-                        return Chip(
-                          materialTapTargetSize:
-                              MaterialTapTargetSize.shrinkWrap,
-                          visualDensity: VisualDensity.compact,
-                          label: Text(
-                            displayName,
-                            style: theme.textTheme.labelSmall,
-                          ),
-                          padding: EdgeInsets.zero,
-                        );
-                      }).toList(),
+                        final entries =
+                            _topSpeciesSci(session).map((entry) {
+                              final displayName =
+                                  taxonomy
+                                      ?.lookup(entry.key)
+                                      ?.commonNameForLocale(speciesLocale) ??
+                                  entry.value;
+                              return displayName;
+                            }).toList()
+                              ..sort((a, b) => a.compareTo(b));
+                        return entries
+                            .map(
+                              (name) => Chip(
+                                materialTapTargetSize:
+                                    MaterialTapTargetSize.shrinkWrap,
+                                visualDensity: VisualDensity.compact,
+                                label: Text(
+                                  name,
+                                  style: theme.textTheme.labelSmall,
+                                ),
+                                padding: EdgeInsets.zero,
+                              ),
+                            )
+                            .toList();
+                      }(),
                 ),
               ],
               const SizedBox(height: 12),
@@ -1728,18 +1736,20 @@ String _sessionTypeLabel(AppLocalizations l10n, SessionType type) {
   }
 }
 
-/// Returns the top 5 most-detected species as (scientificName, commonName)
-/// pairs, ordered by detection count.  The common name is the raw English
+/// Returns the top 5 species by best confidence score as
+/// (scientificName, commonName) pairs. The common name is the raw English
 /// fallback — callers should translate via [TaxonomyService] if available.
+/// Order is unspecified; callers should sort for display.
 List<MapEntry<String, String>> _topSpeciesSci(LiveSession session) {
-  final counts = <String, int>{};
+  final bestScore = <String, double>{};
   final names = <String, String>{};
   for (final d in session.detections) {
-    counts[d.scientificName] = (counts[d.scientificName] ?? 0) + 1;
+    final prev = bestScore[d.scientificName] ?? 0.0;
+    if (d.confidence > prev) bestScore[d.scientificName] = d.confidence;
     names.putIfAbsent(d.scientificName, () => d.commonName);
   }
   final sorted =
-      counts.entries.toList()..sort((a, b) => b.value.compareTo(a.value));
+      bestScore.entries.toList()..sort((a, b) => b.value.compareTo(a.value));
   return sorted.take(5).map((e) => MapEntry(e.key, names[e.key]!)).toList();
 }
 

--- a/lib/features/history/session_review_screen.dart
+++ b/lib/features/history/session_review_screen.dart
@@ -1925,6 +1925,7 @@ class _SessionReviewScreenState extends ConsumerState<SessionReviewScreen> {
 
     final exportFormats = ref.read(exportSelectionProvider);
     final includeAudio = ref.read(includeAudioProvider);
+    final shareAudioAsWav = ref.read(shareAudioAsWavProvider);
     final includeHtmlReport = ref.read(exportHtmlReportProvider);
     final includeAppMetadata = ref.read(includeAppMetadataProvider);
     final taxonomy = ref.read(taxonomyServiceProvider).value;
@@ -1947,6 +1948,7 @@ class _SessionReviewScreenState extends ConsumerState<SessionReviewScreen> {
       widget.session,
       formats: exportFormats,
       includeAudio: includeAudio,
+      shareAudioAsWav: shareAudioAsWav,
       taxonomy: taxonomy,
       speciesLocale: speciesLocale,
       clipContextSecondsOverride: clipContextOverride,
@@ -3958,6 +3960,7 @@ class _SessionReviewScreenState extends ConsumerState<SessionReviewScreen> {
                 (cluster) => shareDetection(
                   cluster.records.first,
                   session: widget.session,
+                  shareAudioAsWav: ref.read(shareAudioAsWavProvider),
                 ),
             onEditNoteCluster: _editClusterNote,
             onEditVoiceMemoCluster: _editClusterVoiceMemo,

--- a/lib/features/history/widgets/clip_player_sheet.dart
+++ b/lib/features/history/widgets/clip_player_sheet.dart
@@ -573,6 +573,7 @@ class _ClipPlayerSheetState extends ConsumerState<_ClipPlayerSheet> {
                         () => shareDetection(
                           widget.detection,
                           session: widget.session,
+                          shareAudioAsWav: ref.read(shareAudioAsWavProvider),
                         ),
                     onDelete:
                         widget.onDelete == null

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -610,6 +610,19 @@ class SettingsScreen extends ConsumerWidget {
                     (v) =>
                         ref.read(includeAudioProvider.notifier).set(v ?? false),
               ),
+              if (ref.watch(includeAudioProvider))
+                CheckboxListTile(
+                  dense: true,
+                  title: _TitleWithHelp(
+                    title: l10n.settingsShareAudioAsWav,
+                    helpBody: l10n.settingsHelpShareAudioAsWav,
+                  ),
+                  value: ref.watch(shareAudioAsWavProvider),
+                  onChanged:
+                      (v) => ref
+                          .read(shareAudioAsWavProvider.notifier)
+                          .set(v ?? false),
+                ),
               CheckboxListTile(
                 dense: true,
                 title: _TitleWithHelp(

--- a/lib/features/survey/survey_live_screen.dart
+++ b/lib/features/survey/survey_live_screen.dart
@@ -912,7 +912,11 @@ class _SurveyLiveScreenState extends ConsumerState<SurveyLiveScreen>
                         detection.isConfirmed ? null : DateTime.now().toUtc();
                   });
                 },
-                onShare: () => shareDetection(detection, session: session),
+                onShare: () => shareDetection(
+                  detection,
+                  session: session,
+                  shareAudioAsWav: ref.read(shareAudioAsWavProvider),
+                ),
                 onDelete: () => _deleteLiveDetectionWithUndo(detection),
               ),
         ),

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -926,6 +926,8 @@
   "settingsSpectrogramQualityMedium": "Střední",
   "settingsSpectrogramQualityHigh": "Vysoká",
   "settingsIncludeAudioFiles": "Zahrnout zvukové soubory",
+  "settingsShareAudioAsWav": "Vždy sdílet zvuk jako WAV",
+  "settingsHelpShareAudioAsWav": "Pokud je povoleno, budou nahrávky FLAC před sdílením nebo exportem převedeny na WAV. Soubory WAV jsou univerzálně kompatibilní, ale výrazně větší než FLAC.",
   "sessionWeatherSection": "Počasí",
   "sessionWeatherAttribution": "Data o počasí: Open-Meteo",
   "sessionWeatherCondition": "Stav",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -807,6 +807,8 @@
   "settingsSpectrogramQualityMedium": "Mittel",
   "settingsSpectrogramQualityHigh": "Hoch",
   "settingsIncludeAudioFiles": "Audiodateien einschließen",
+  "settingsShareAudioAsWav": "Audio immer als WAV teilen",
+  "settingsHelpShareAudioAsWav": "Wenn aktiviert, werden FLAC-Aufnahmen vor dem Teilen oder Exportieren in WAV konvertiert. WAV-Dateien sind universell kompatibel, aber deutlich größer als FLAC.",
   "settingsExportHtmlReport": "HTML-Bericht einschließen",
   "settingsExportAppMetadata": "App-Metadaten einschließen",
   "settingsPrivacy": "Datenschutz",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3520,6 +3520,14 @@
   "@settingsIncludeAudioFiles": {
     "description": "Setting to include audio files in export"
   },
+  "settingsShareAudioAsWav": "Always share audio as WAV",
+  "@settingsShareAudioAsWav": {
+    "description": "Setting to convert FLAC audio to WAV before sharing"
+  },
+  "settingsHelpShareAudioAsWav": "When enabled, FLAC recordings are converted to WAV before sharing or exporting. WAV files are universally compatible but significantly larger than FLAC.",
+  "@settingsHelpShareAudioAsWav": {
+    "description": "Help text for the share audio as WAV setting"
+  },
   "settingsOfflineMapDownload": "Download offline maps",
   "@settingsOfflineMapDownload": {
     "description": "Settings tile that lets the user pre-cache OSM tiles for an area"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -791,6 +791,8 @@
   "settingsSpectrogramQualityMedium": "Media",
   "settingsSpectrogramQualityHigh": "Alta",
   "settingsIncludeAudioFiles": "Incluir archivos de audio",
+  "settingsShareAudioAsWav": "Compartir audio siempre como WAV",
+  "settingsHelpShareAudioAsWav": "Cuando está activado, las grabaciones FLAC se convierten a WAV antes de compartirlas o exportarlas. Los archivos WAV son universalmente compatibles pero significativamente más grandes que FLAC.",
   "sessionWeatherSection": "Clima",
   "sessionWeatherAttribution": "Datos del clima: Open-Meteo",
   "sessionWeatherCondition": "Condición",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -791,6 +791,8 @@
   "settingsSpectrogramQualityMedium": "Moyenne",
   "settingsSpectrogramQualityHigh": "Haute",
   "settingsIncludeAudioFiles": "Inclure les fichiers audio",
+  "settingsShareAudioAsWav": "Toujours partager l'audio en WAV",
+  "settingsHelpShareAudioAsWav": "Lorsque cette option est activée, les enregistrements FLAC sont convertis en WAV avant d'être partagés ou exportés. Les fichiers WAV sont universellement compatibles mais nettement plus volumineux que le FLAC.",
   "sessionWeatherSection": "Météo",
   "sessionWeatherAttribution": "Données météo : Open-Meteo",
   "sessionWeatherCondition": "Condition",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -791,6 +791,8 @@
   "settingsSpectrogramQualityMedium": "Media",
   "settingsSpectrogramQualityHigh": "Alta",
   "settingsIncludeAudioFiles": "Includi file audio",
+  "settingsShareAudioAsWav": "Condividi sempre l'audio come WAV",
+  "settingsHelpShareAudioAsWav": "Se abilitato, le registrazioni FLAC vengono convertite in WAV prima di essere condivise o esportate. I file WAV sono universalmente compatibili ma significativamente più grandi dei file FLAC.",
   "sessionWeatherSection": "Meteo",
   "sessionWeatherAttribution": "Dati meteo: Open-Meteo",
   "sessionWeatherCondition": "Condizione",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -791,6 +791,8 @@
   "settingsSpectrogramQualityMedium": "Média",
   "settingsSpectrogramQualityHigh": "Alta",
   "settingsIncludeAudioFiles": "Incluir arquivos de áudio",
+  "settingsShareAudioAsWav": "Sempre partilhar áudio como WAV",
+  "settingsHelpShareAudioAsWav": "Quando ativado, as gravações FLAC são convertidas para WAV antes de serem partilhadas ou exportadas. Os ficheiros WAV são universalmente compatíveis mas significativamente maiores do que o FLAC.",
   "sessionWeatherSection": "Clima",
   "sessionWeatherAttribution": "Dados de clima: Open-Meteo",
   "sessionWeatherCondition": "Condição",

--- a/lib/shared/providers/settings_providers.dart
+++ b/lib/shared/providers/settings_providers.dart
@@ -291,6 +291,14 @@ final includeAudioProvider = StateNotifierProvider<BoolSettingNotifier, bool>((
   return BoolSettingNotifier(prefs, PrefKeys.includeAudio, true);
 });
 
+/// Convert FLAC recordings to WAV before sharing/exporting (default false).
+/// WAV is universally compatible but larger; FLAC is lossless compressed.
+final shareAudioAsWavProvider =
+    StateNotifierProvider<BoolSettingNotifier, bool>((ref) {
+      final prefs = ref.watch(sharedPreferencesProvider);
+      return BoolSettingNotifier(prefs, PrefKeys.shareAudioAsWav, false);
+    });
+
 /// Bundle a self-contained `report.html` next to the audio inside the
 /// export ZIP (default true). The HTML opens in any browser, embeds the
 /// session metadata + clip players, and pulls species images / data

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: birdnet_live
 description: "Real-time bird species identification using on-device ONNX inference"
 publish_to: 'none'
-version: 0.17.16+196
+version: 0.17.17+197
 
 environment:
   sdk: ^3.7.0


### PR DESCRIPTION
Add an option in settings to export audio recordings as WAV files, enhancing interoperability with iNaturalist and similar applications. This update also includes sorting of species chips alphabetically and version increment to 0.17.17.

Fixes #123