### PR TITLE
Add foreground GPS tracking option and manage lifecycle states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Sort species chips in session card alphabetically and update top species logic
 
+### Fixes
+
+- Add foreground GPS tracking option and manage lifecycle states.
+
 ## [0.17.16] - 2026-06-24
 
 ### Added

--- a/lib/features/survey/survey_controller.dart
+++ b/lib/features/survey/survey_controller.dart
@@ -366,6 +366,7 @@ class SurveyController {
     double? startLatitude,
     double? startLongitude,
     bool backgroundGps = true,
+    bool foregroundGps = false,
     int autoStopBattery = 0,
     SessionSettings? settingsSnapshot,
     int? poolingWindows,
@@ -468,7 +469,7 @@ class SurveyController {
       // GPS tracking.
       _gpsTracker = SurveyGpsTracker(intervalSeconds: gpsIntervalSeconds);
       _gpsTracker!.onPoint = _onGpsPoint;
-      if (backgroundGps) {
+      if (backgroundGps || foregroundGps) {
         await _gpsTracker!.startTracking();
       } else {
         // Manual GPS mode: capture initial fix.
@@ -550,6 +551,7 @@ class SurveyController {
     required SamplingMode samplingMode,
     int topNPerSpecies = 10,
     bool backgroundGps = true,
+    bool foregroundGps = false,
     int autoStopBattery = 0,
     int? poolingWindows,
     String poolingMode = 'lme',
@@ -614,7 +616,7 @@ class SurveyController {
       _gpsTracker = SurveyGpsTracker(intervalSeconds: gpsIntervalSeconds);
       _gpsTracker!.onPoint = _onGpsPoint;
       _gpsTracker!.seedTrack(existingSession.gpsTrack);
-      if (backgroundGps) {
+      if (backgroundGps || foregroundGps) {
         await _gpsTracker!.startTracking();
       } else {
         await _gpsTracker!.captureOnce();

--- a/lib/features/survey/survey_live_screen.dart
+++ b/lib/features/survey/survey_live_screen.dart
@@ -21,6 +21,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:birdnet_live/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:latlong2/latlong.dart';
@@ -91,6 +92,7 @@ class _SurveyLiveScreenState extends ConsumerState<SurveyLiveScreen>
   bool _started = false;
   bool _finalizing = false;
   bool _stopDialogShowing = false;
+  bool _foregroundGpsStream = false;
   StreamSubscription<bool>? _micContestedSub;
   late final TabController _tabController;
   late final SurveyController _surveyController;
@@ -566,6 +568,16 @@ class _SurveyLiveScreenState extends ConsumerState<SurveyLiveScreen>
       micContested: l10n.surveyNotificationMicContested,
     );
 
+    // With whileInUse permission, use the GPS stream while in the foreground.
+    // The screen's lifecycle handler will stop/restart it as the app is
+    // backgrounded and foregrounded.
+    if (!widget.backgroundGps) {
+      final permission = await Geolocator.checkPermission();
+      _foregroundGpsStream =
+          permission == LocationPermission.whileInUse ||
+          permission == LocationPermission.always;
+    }
+
     if (widget.resumeSession != null) {
       await controller.resumeSurvey(
         existingSession: widget.resumeSession!,
@@ -583,6 +595,7 @@ class _SurveyLiveScreenState extends ConsumerState<SurveyLiveScreen>
         samplingMode: samplingMode,
         topNPerSpecies: topN,
         backgroundGps: widget.backgroundGps,
+        foregroundGps: _foregroundGpsStream,
         autoStopBattery: autoStopBattery,
         poolingWindows: ref.read(scorePoolingWindowsProvider),
         poolingMode: ref.read(scorePoolingProvider),
@@ -610,6 +623,7 @@ class _SurveyLiveScreenState extends ConsumerState<SurveyLiveScreen>
         startLatitude: widget.startLatitude,
         startLongitude: widget.startLongitude,
         backgroundGps: widget.backgroundGps,
+        foregroundGps: _foregroundGpsStream,
         autoStopBattery: autoStopBattery,
         poolingWindows: ref.read(scorePoolingWindowsProvider),
         poolingMode: ref.read(scorePoolingProvider),
@@ -716,9 +730,19 @@ class _SurveyLiveScreenState extends ConsumerState<SurveyLiveScreen>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    // In manual GPS mode, capture a fix when the user returns to the app.
-    if (state == AppLifecycleState.resumed && !widget.backgroundGps) {
-      ref.read(surveyControllerProvider).captureGpsFix();
+    final controller = ref.read(surveyControllerProvider);
+    if (_foregroundGpsStream && !widget.backgroundGps) {
+      // Foreground-only GPS: stop the stream when backgrounded so the OS
+      // doesn't revoke whileInUse location access, and restart it when the
+      // user brings the app back to the front.
+      if (state == AppLifecycleState.paused) {
+        controller.gpsTracker?.stopTracking();
+      } else if (state == AppLifecycleState.resumed) {
+        controller.gpsTracker?.startTracking();
+      }
+    } else if (state == AppLifecycleState.resumed && !widget.backgroundGps) {
+      // Manual GPS mode: capture a single fix when the user returns.
+      controller.captureGpsFix();
     }
   }
 


### PR DESCRIPTION
Enhance the survey tool by introducing a foreground GPS tracking option that allows for continuous location updates while the app is active. This update manages the app's lifecycle states to ensure GPS tracking is paused when the app goes into the background, preventing location access issues. Additionally, the implementation provides a clearer user experience regarding location permissions.

Fixes #132