### PR TITLE
Fix JSON export and adjust smart mode rivalry logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add foreground GPS tracking option and manage lifecycle states.
 - Improve text fitting for offset display in species card in session review
 - Swap yelwar and yelwa1
+- Include notes and voice memos in JSON export and enforce ZIP bundling for annotations and memos
 
 ## [0.17.16] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve text fitting for offset display in species card in session review
 - Swap yelwar and yelwa1
 - Include notes and voice memos in JSON export and enforce ZIP bundling for annotations and memos
+- Adjust smart mode rivalry logic to trigger only after topN slots are filled
 
 ## [0.17.16] - 2026-06-24
 

--- a/lib/features/aru/aru_detection_sampler.dart
+++ b/lib/features/aru/aru_detection_sampler.dart
@@ -13,7 +13,7 @@ import '../survey/detection_sampler.dart';
 ///
 /// Selection mirrors the Survey [DetectionSampler] exactly — Top N
 /// highest-confidence clips per species, with a Smart mode that adds same-spot
-/// rivalry and a [minKeepPerSpecies] floor — with one deliberate difference:
+/// rivalry once all topN slots are filled — with one deliberate difference:
 /// ARU deployments are stationary, so the Survey "same spot" test reduces to a
 /// **time-only** proximity check (no haversine distance). Two detections of the
 /// same species within [timeThresholdSeconds] are treated as the same
@@ -31,7 +31,6 @@ class AruDetectionSampler {
     required this.mode,
     this.topN = 10,
     this.timeThresholdSeconds = 120,
-    this.minKeepPerSpecies = 3,
     String Function(DetectionRecord record)? scopeKeyFor,
   }) : _scopeKeyFor = scopeKeyFor;
 
@@ -46,12 +45,6 @@ class AruDetectionSampler {
   /// vocalization. Mirrors the Survey sampler's time threshold; distance is not
   /// used because ARU deployments are stationary.
   final int timeThresholdSeconds;
-
-  /// Smart mode only: minimum number of clips to retain per species before
-  /// same-spot rivalry kicks in. Until a species has this many kept clips, new
-  /// detections fall through to the standard Top N admission path even if a
-  /// same-spot neighbor exists.
-  final int minKeepPerSpecies;
 
   final String Function(DetectionRecord record)? _scopeKeyFor;
 
@@ -74,10 +67,9 @@ class AruDetectionSampler {
     final groupKey = _groupKey(record);
     final kept = _keptClips.putIfAbsent(groupKey, () => []);
 
-    // Smart mode: check for a same-spot rival first. If one exists, the contest
-    // is between just those two regardless of free slots — but only after the
-    // per-species minimum has been met, so the first few clips always survive.
-    if (mode == SamplingMode.smart && kept.length >= minKeepPerSpecies) {
+    // Smart mode: same-spot rivalry only kicks in once all topN slots are
+    // filled. Until then, clips are admitted freely via the Top N path below.
+    if (mode == SamplingMode.smart && kept.length >= topN) {
       final neighbor = _findSameSpot(record, kept);
       if (neighbor != null) {
         if (record.confidence > neighbor.confidence) {

--- a/lib/features/history/session_export.dart
+++ b/lib/features/history/session_export.dart
@@ -714,6 +714,9 @@ String buildJsonExport(LiveSession session, {Map<String, dynamic>? metadata}) {
             'confirmed': d.isConfirmed,
             if (d.confirmedAt != null)
               'confirmedAt': d.confirmedAt!.toUtc().toIso8601String(),
+            if (d.hasNote) 'note': d.note,
+            if (d.hasVoiceMemo)
+              'voiceMemo': 'memos/${p.basename(d.voiceMemoPath!)}',
           };
         }).toList(),
     if (session.annotations.isNotEmpty)
@@ -976,13 +979,20 @@ Future<String?> buildSessionExport(
       includeHtmlReport ||
       (includeAppMetadata && exportMetadata != null) ||
       session.annotations.isNotEmpty;
+  final hasMemos = session.detections.any((d) => d.hasVoiceMemo);
   final mustZip =
       (includeAudio && hasAruCycleAudio) ||
       (includeAudio && hasClips) ||
       (includeAudio && hasFullRecording && hasCompanion) ||
       docs.length > 1 ||
       includeHtmlReport ||
-      (docs.isNotEmpty && includeAppMetadata && exportMetadata != null);
+      (docs.isNotEmpty && includeAppMetadata && exportMetadata != null) ||
+      // Session annotations and detection voice memos each produce companion
+      // files (annotations.txt, memos/) that only exist inside a ZIP bundle.
+      // Force ZIP whenever either is present alongside at least one document
+      // so these files are never silently dropped from the export.
+      (docs.isNotEmpty && session.annotations.isNotEmpty) ||
+      (docs.isNotEmpty && hasMemos);
 
   // Audio-only mode: the user unchecked every companion (no formats,
   // no HTML, no app metadata). For full-recording sessions we share the

--- a/lib/features/survey/detection_sampler.dart
+++ b/lib/features/survey/detection_sampler.dart
@@ -17,16 +17,13 @@
 //     than the weakest existing clip, the new one's clip is dropped on
 //     arrival.
 //   * **Smart** — same per-species cap of N, but with spatial distribution.
-//     If a new detection lands at the same "spot" as an already-kept clip
+//     Once a species has filled all N slots, same-spot rivalry kicks in: if
+//     a new detection lands at the same "spot" as an already-kept clip
 //     (within distance + time thresholds: 250 m **or** 2 min), only the
-//     higher-confidence clip survives — even if there's still a free slot.
-//     This prevents one stationary singer from grabbing all N slots.
-//
-//     A floor of [minKeepPerSpecies] (default 3) clips per species is
-//     always honored: until that many clips are retained for a species,
-//     same-spot rivalry is bypassed and clips are admitted via the normal
-//     Top N path. This guarantees a few representative recordings even for
-//     birds that only call from one spot.
+//     higher-confidence clip survives. Until the N slots are full, clips are
+//     always admitted via the normal Top N path regardless of location.
+//     This ensures every species always gets up to N clips before any are
+//     rejected for being at the same spot.
 //
 // Records always live in the session. Only `audioClipPath` is affected.
 // =============================================================================
@@ -77,7 +74,6 @@ class DetectionSampler {
     this.topN = 10,
     this.distanceThresholdMeters = 250,
     this.timeThresholdSeconds = 120,
-    this.minKeepPerSpecies = 3,
   });
 
   /// Active sampling mode.
@@ -95,12 +91,6 @@ class DetectionSampler {
   /// closer than [distanceThresholdMeters] **and** within this time window
   /// are considered the same spot.
   final int timeThresholdSeconds;
-
-  /// Smart mode only: minimum number of clips to retain per species before
-  /// same-spot rivalry kicks in. Until a species has this many kept clips,
-  /// new detections fall through to the standard Top N admission path even
-  /// if a same-spot neighbor exists.
-  final int minKeepPerSpecies;
 
   /// Per-species lists of records whose clips are currently kept on disk,
   /// sorted ascending by confidence (weakest at index 0).
@@ -131,11 +121,9 @@ class DetectionSampler {
     final species = record.scientificName;
     final kept = _keptClips.putIfAbsent(species, () => []);
 
-    // Smart mode: check for a same-spot rival first. If one exists, the
-    // contest is between just those two regardless of free slots — but
-    // only after the per-species minimum has been met, so the first few
-    // clips of a species always survive.
-    if (mode == SamplingMode.smart && kept.length >= minKeepPerSpecies) {
+    // Smart mode: same-spot rivalry only kicks in once all topN slots are
+    // filled. Until then, clips are admitted freely via the Top N path below.
+    if (mode == SamplingMode.smart && kept.length >= topN) {
       final neighbor = _findSameSpot(record, kept);
       if (neighbor != null) {
         if (record.confidence > neighbor.confidence) {

--- a/test/features/aru/aru_detection_sampler_test.dart
+++ b/test/features/aru/aru_detection_sampler_test.dart
@@ -57,10 +57,10 @@ void main() {
     test('smart mode keeps stronger clip from the same time window', () async {
       final sampler = AruDetectionSampler(
         mode: SamplingMode.smart,
-        topN: 3,
-        minKeepPerSpecies: 0,
+        topN: 1,
       );
       // Two detections seconds apart (within the same-spot time window).
+      // topN=1: the first fills the slot, the second triggers rivalry and wins.
       final weaker = record(confidence: 0.4, secondsIntoCycle: 0);
       final stronger = record(confidence: 0.8, secondsIntoCycle: 10);
 
@@ -72,24 +72,29 @@ void main() {
       expect(sampler.keptClipCount, 1);
     });
 
-    test('smart mode honors the per-species minimum before rivalry', () async {
+    test('smart mode admits same-spot clips freely until topN, then rivalry',
+        () async {
       final sampler = AruDetectionSampler(
         mode: SamplingMode.smart,
-        topN: 5,
-        minKeepPerSpecies: 3,
+        topN: 3,
       );
-      // All within the same time window, but the floor keeps the first three.
+      // All within the same time window. Rivalry doesn't fire until topN is
+      // full, so all three are kept.
       final a = record(confidence: 0.4, secondsIntoCycle: 0, clip: 'a.flac');
       final b = record(confidence: 0.5, secondsIntoCycle: 10, clip: 'b.flac');
       final c = record(confidence: 0.6, secondsIntoCycle: 20, clip: 'c.flac');
+      // Fourth same-window clip: topN full, rivalry fires, weaker d loses.
+      final d = record(confidence: 0.3, secondsIntoCycle: 30, clip: 'd.flac');
 
       expect(await sampler.onRecordClosed(a), isTrue);
       expect(await sampler.onRecordClosed(b), isTrue);
       expect(await sampler.onRecordClosed(c), isTrue);
+      expect(await sampler.onRecordClosed(d), isFalse);
 
       expect(a.audioClipPath, isNotNull);
       expect(b.audioClipPath, isNotNull);
       expect(c.audioClipPath, isNotNull);
+      expect(d.audioClipPath, isNull);
       expect(sampler.keptClipCount, 3);
     });
 
@@ -97,9 +102,9 @@ void main() {
       final sampler = AruDetectionSampler(
         mode: SamplingMode.smart,
         topN: 2,
-        minKeepPerSpecies: 0,
       );
-      // Same window: only the stronger survives.
+      // Same window: both admitted (topN=2 not yet full), then window1 evicts
+      // the weaker one when the budget is full.
       final window0Low = record(
         confidence: 0.4,
         secondsIntoCycle: 0,
@@ -140,7 +145,6 @@ void main() {
       final sampler = AruDetectionSampler(
         mode: SamplingMode.smart,
         topN: 1,
-        minKeepPerSpecies: 0,
         scopeKeyFor:
             (record) => 'cycle-${record.timestamp.difference(start).inHours}',
       );
@@ -161,7 +165,6 @@ void main() {
         final sampler = AruDetectionSampler(
           mode: SamplingMode.smart,
           topN: 1,
-          minKeepPerSpecies: 10,
         );
         final original = record(
           confidence: 0.8,

--- a/test/features/survey/detection_sampler_test.dart
+++ b/test/features/survey/detection_sampler_test.dart
@@ -181,10 +181,9 @@ void main() {
     test('evicts weaker clip at the same spot', () async {
       final sampler = DetectionSampler(
         mode: SamplingMode.smart,
-        topN: 5,
+        topN: 1,
         distanceThresholdMeters: 500,
         timeThresholdSeconds: 120,
-        minKeepPerSpecies: 0,
       );
 
       final d1 = await _det('Parus major', 0.5,
@@ -222,10 +221,9 @@ void main() {
     test('drops new clip if weaker at the same spot', () async {
       final sampler = DetectionSampler(
         mode: SamplingMode.smart,
-        topN: 5,
+        topN: 1,
         distanceThresholdMeters: 500,
         timeThresholdSeconds: 120,
-        minKeepPerSpecies: 0,
       );
 
       final d1 = await _det('Parus major', 0.9,
@@ -269,10 +267,9 @@ void main() {
     test('missing GPS falls back to time-only same-spot check', () async {
       final sampler = DetectionSampler(
         mode: SamplingMode.smart,
-        topN: 5,
+        topN: 1,
         distanceThresholdMeters: 500,
         timeThresholdSeconds: 120,
-        minKeepPerSpecies: 0,
       );
 
       // No GPS on either record; within the time window â†’ same spot.
@@ -286,26 +283,25 @@ void main() {
       expect(d2.audioClipPath, isNotNull);
     });
 
-    test('keeps minKeepPerSpecies clips even at the same spot', () async {
+    test('admits same-spot clips freely until topN, then applies rivalry',
+        () async {
       final sampler = DetectionSampler(
         mode: SamplingMode.smart,
-        topN: 10,
+        topN: 3,
         distanceThresholdMeters: 250,
         timeThresholdSeconds: 120,
-        minKeepPerSpecies: 3,
       );
 
-      // Three same-spot detections of the same species. With the
-      // minKeepPerSpecies floor, all three should be retained even though
-      // they would otherwise lose a same-spot rivalry.
+      // Three same-spot detections all within the time window. All should be
+      // kept because rivalry doesn't fire until the topN slots are full.
       final d1 = await _det('Parus major', 0.5,
           offset: Duration.zero, latitude: 52.0, longitude: 13.0);
       final d2 = await _det('Parus major', 0.6,
           offset: const Duration(seconds: 10), latitude: 52.0, longitude: 13.0);
       final d3 = await _det('Parus major', 0.7,
           offset: const Duration(seconds: 20), latitude: 52.0, longitude: 13.0);
-      // Fourth same-spot detection should now lose to the weakest neighbor
-      // because the floor has been met.
+      // Fourth same-spot detection: topN is now full, so rivalry fires and
+      // this weaker clip loses to the weakest already-kept clip.
       final d4 = await _det('Parus major', 0.4,
           offset: const Duration(seconds: 30), latitude: 52.0, longitude: 13.0);
 


### PR DESCRIPTION
Include notes and voice memos in the JSON export while enforcing ZIP bundling for annotations and memos. Adjust the smart mode rivalry logic to trigger only after all topN slots are filled.