### PR TITLE
Use Japanese locale for English fallback in settings test

### DIFF
--- a/test/shared/providers/settings_providers_test.dart
+++ b/test/shared/providers/settings_providers_test.dart
@@ -172,7 +172,7 @@ void main() {
           overrides: [
             sharedPreferencesProvider.overrideWithValue(prefs),
             platformLocalesProvider.overrideWithValue(const [
-              Locale('ru', 'RU'),
+              Locale('ja', 'JP'),
             ]),
           ],
         );


### PR DESCRIPTION
Update the fallback locale in the settings test to use Japanese instead of Russian.