### PR TITLE
Fix audio timing and export alignment for resumed surveys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a serious problem where another app taking the microphone during a survey (for example, opening the camera to shoot a video) could leave the phone unable to record audio in any app until it was rebooted. The app no longer keeps re-grabbing a microphone it can't have while running in the background, which was what wedged the device audio system. Losing the microphone is now handled gracefully: the survey signal meter shows a crossed-out mic, the ongoing notification explains that another app is using the microphone, and audio recording resumes automatically as soon as you return to the app.
+- Resuming a survey from Session Review now keeps the elapsed timer running correctly. Previously the counter froze shortly after resuming and the saved duration came out too short; the timer now continues from where it left off and counts only time the survey is actively recording, excluding the gap while it was stopped. The live detections-per-minute rate is likewise now based on active recording time rather than wall-clock time since the survey first started.
+- Detection timestamps in exports (Raven selection tables, CSV, and JSON) now line up with the audio for resumed survey sessions. Offsets are measured against the actual recorded audio with the stopped gap removed, matching in-app playback, instead of counting the pause as if it were recorded.
+- The "recording shorter than session" warning in Session Review and exports now measures the expected audio length the same way (gap-removed), so resumed sessions are no longer falsely flagged as truncated.
+
+### Changed
+
+- The **Continue Survey** button in Session Review is now hidden for sessions that recorded full audio, because a continuous audio file can't be safely extended across a stop-and-resume. Surveys recorded with clip subsampling (or no audio) can still be resumed as before, and a resumed survey now keeps its original recording mode.
 
 ## [0.18.9] - 2026-07-11
 

--- a/lib/features/history/services/detection_audio_window.dart
+++ b/lib/features/history/services/detection_audio_window.dart
@@ -20,9 +20,12 @@ DetectionAudioWindow detectionAudioWindow(
   double? clipContextSeconds,
 }) {
   final context = math.max(0.0, clipContextSeconds ?? 0.0);
-  final start =
-      detection.timestamp.difference(session.startTime).inMicroseconds /
-      Duration.microsecondsPerSecond;
+  // Offset into the *recorded* audio timeline, which is a gap-removed
+  // concatenation of the session's segments. absoluteToRelative collapses
+  // any pause/resume gaps so a resumed session's detections line up with
+  // the actual audio position (matching in-app playback). For single-run
+  // sessions (no segments) this reduces to timestamp - startTime.
+  final start = session.absoluteToRelative(detection.timestamp);
   final duration = detectionDurationSeconds(detection, session.settings);
   final clipStart = math.max(0.0, start - context);
   final detectionStartInClip = start - clipStart;

--- a/lib/features/history/session_export.dart
+++ b/lib/features/history/session_export.dart
@@ -27,7 +27,6 @@
 
 import 'dart:convert';
 import 'dart:io';
-import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:archive/archive.dart';
@@ -199,11 +198,10 @@ String buildRavenSelectionTable(
     '${hasNotes ? '\tNote' : ''}',
   );
 
-  final sessionDurationSec =
-      session.endTime != null
-          ? session.endTime!.difference(session.startTime).inMilliseconds /
-              1000.0
-          : 0.0;
+  // Length of the recorded audio timeline, used as the end offset for
+  // whole-session (global) clips. Segment-backed sessions use their exact
+  // gap-removed timeline so resumed sessions don't include stopped time.
+  final sessionDurationSec = _recordedTimelineDurationSeconds(session);
 
   for (var i = 0; i < session.detections.length; i++) {
     final d = session.detections[i];
@@ -340,11 +338,10 @@ String buildCsvExport(
     '${hasMemos ? ',Voice Memo' : ''}',
   );
 
-  final sessionDurationSec =
-      session.endTime != null
-          ? session.endTime!.difference(session.startTime).inMilliseconds /
-              1000.0
-          : 0.0;
+  // Length of the recorded audio timeline, used as the end offset for
+  // whole-session (global) clips. Segment-backed sessions use their exact
+  // gap-removed timeline so resumed sessions don't include stopped time.
+  final sessionDurationSec = _recordedTimelineDurationSeconds(session);
 
   for (var i = 0; i < session.detections.length; i++) {
     final d = session.detections[i];
@@ -721,8 +718,9 @@ String buildJsonExport(
     if (session.aruMetadata != null) 'aru': session.aruMetadata!.toJson(),
     'detections':
         session.detections.map((d) {
-          final beginSec =
-              d.timestamp.difference(session.startTime).inMilliseconds / 1000.0;
+          // Gap-removed offset into the recorded audio (see
+          // absoluteToRelative); keeps resumed sessions aligned.
+          final beginSec = session.absoluteToRelative(d.timestamp);
           return {
             'timestamp': d.timestamp.toUtc().toIso8601String(),
             'beginTimeSec': num.parse(beginSec.toStringAsFixed(3)),
@@ -764,21 +762,7 @@ Future<Map<String, dynamic>?> _withAudioIntegrityMetadata(
               _formatLabelForPath(audioPath),
             );
     final audioSec = audio.duration.inMicroseconds / 1e6;
-    var expectedSec = 0.0;
-    final end = session.endTime;
-    if (end != null) {
-      expectedSec = math.max(
-        expectedSec,
-        end.difference(session.startTime).inMicroseconds / 1e6,
-      );
-    }
-    for (final detection in session.detections) {
-      final eventEnd = detection.endTimestamp ?? detection.timestamp;
-      expectedSec = math.max(
-        expectedSec,
-        eventEnd.difference(session.startTime).inMicroseconds / 1e6,
-      );
-    }
+    final expectedSec = session.expectedRecordedAudioSeconds;
     if (expectedSec <= 0 || audioSec + 5 >= expectedSec) return metadata;
 
     final enriched = <String, dynamic>{...?metadata};
@@ -794,6 +778,13 @@ Future<Map<String, dynamic>?> _withAudioIntegrityMetadata(
   } catch (_) {
     return metadata;
   }
+}
+
+double _recordedTimelineDurationSeconds(LiveSession session) {
+  if (session.segments.isNotEmpty) {
+    return session.absoluteToRelative(session.endTime ?? DateTime.now());
+  }
+  return session.duration.inMicroseconds / 1e6;
 }
 
 Map<String, dynamic> _withAruCycleExportFiles(

--- a/lib/features/history/session_review_screen.dart
+++ b/lib/features/history/session_review_screen.dart
@@ -1078,26 +1078,7 @@ class _SessionReviewScreenState extends ConsumerState<SessionReviewScreen> {
                 _formatLabelForPath(path),
               );
       final audioSec = metadata.duration.inMicroseconds / 1e6;
-      var expectedSec = 0.0;
-      final recordedSec = widget.session.recordedDurationSeconds?.toDouble();
-      if (recordedSec != null && recordedSec > 0) {
-        expectedSec = recordedSec;
-      } else {
-        final end = widget.session.endTime;
-        if (end != null) {
-          expectedSec = math.max(
-            expectedSec,
-            end.difference(widget.session.startTime).inMicroseconds / 1e6,
-          );
-        }
-        for (final detection in widget.session.detections) {
-          final eventEnd = detection.endTimestamp ?? detection.timestamp;
-          expectedSec = math.max(
-            expectedSec,
-            eventEnd.difference(widget.session.startTime).inMicroseconds / 1e6,
-          );
-        }
-      }
+      final expectedSec = widget.session.expectedRecordedAudioSeconds;
       final isTruncated = expectedSec > 0 && audioSec + 5 < expectedSec;
       if (mounted && isTruncated != _audioTruncatedWarning) {
         setState(() => _audioTruncatedWarning = isTruncated);
@@ -1973,6 +1954,26 @@ class _SessionReviewScreenState extends ConsumerState<SessionReviewScreen> {
     if (mounted) Navigator.of(context).pop();
   }
 
+  /// Whether this session may be resumed ("Continue survey").
+  ///
+  /// Only survey sessions qualify, and only when they were NOT recorded in
+  /// full-audio mode. Full-audio recordings are a single continuous file that
+  /// cannot be safely concatenated across a stop/resume (the FLAC stream is
+  /// already finalized), so resuming them would desync the audio timeline
+  /// from the detections. Clip-subsampling and no-recording sessions have no
+  /// such continuous file and resume cleanly.
+  bool get _canContinueSurvey {
+    if (widget.session.type != SessionType.survey) return false;
+    return switch (widget.session.settings.recordingMode) {
+      'detections' || 'detectionsOnly' || 'off' => true,
+      // A legacy session without a recording-mode snapshot is safe to resume
+      // only when it has no associated audio. An existing path may point to a
+      // finalized full recording, which must not be overwritten.
+      null => widget.session.recordingPath == null,
+      _ => false,
+    };
+  }
+
   /// Resume an unfinished survey session (after user confirmation).
   Future<void> _continueSurvey() async {
     final l10n = AppLocalizations.of(context)!;
@@ -2448,10 +2449,7 @@ class _SessionReviewScreenState extends ConsumerState<SessionReviewScreen> {
       context: context,
       isScrollControlled: true,
       useSafeArea: true,
-      builder:
-          (_) => _SessionHelpSheet(
-            showContinueSurvey: widget.session.type == SessionType.survey,
-          ),
+      builder: (_) => _SessionHelpSheet(showContinueSurvey: _canContinueSurvey),
     );
   }
 
@@ -3661,7 +3659,7 @@ class _SessionReviewScreenState extends ConsumerState<SessionReviewScreen> {
             tooltip: l10n.sessionDiscard,
             onPressed: _discard,
           ),
-          if (widget.session.type == SessionType.survey)
+          if (_canContinueSurvey)
             IconButton(
               icon: Icon(
                 AppIcons.playArrowRounded,

--- a/lib/features/live/live_session.dart
+++ b/lib/features/live/live_session.dart
@@ -989,6 +989,37 @@ class LiveSession {
     return (endTime ?? DateTime.now()).difference(startTime);
   }
 
+  /// Expected length of the concatenated recorded audio in seconds, with
+  /// pause/resume gaps removed.
+  ///
+  /// Used to detect a truncated recording (an audio file that ends before the
+  /// session's latest event) without falsely flagging resumed sessions, whose
+  /// wall-clock span includes the stopped gap. Shared by the export and
+  /// Session Review integrity checks so both agree.
+  double get expectedRecordedAudioSeconds {
+    if (segments.isNotEmpty) {
+      // Segment timestamps retain sub-second precision and collapse resume
+      // gaps, so they are the closest model of the concatenated audio.
+      return absoluteToRelative(endTime ?? DateTime.now());
+    }
+    // No segments: fall back to the accumulated recorded seconds, else the
+    // wall-clock span, then extend to cover any detection that ends later.
+    final recorded = _recordedDurationSeconds?.toDouble();
+    final end = endTime;
+    var expected =
+        recorded != null && recorded > 0
+            ? recorded
+            : end == null
+            ? 0.0
+            : end.difference(startTime).inMicroseconds / 1e6;
+    for (final detection in detections) {
+      final eventEnd = detection.endTimestamp ?? detection.timestamp;
+      final rel = absoluteToRelative(eventEnd);
+      if (rel > expected) expected = rel;
+    }
+    return expected;
+  }
+
   /// Number of unique species detected.
   int get uniqueSpeciesCount =>
       detections.map((d) => d.scientificName).toSet().length;
@@ -1163,6 +1194,30 @@ class LiveSession {
       }
     }
     segments.add(SessionSegment(startTime: now));
+  }
+
+  /// Reactivates an ended session and opens a distinct recording segment.
+  ///
+  /// A resume must never use [startSegment]'s short-gap merge behavior:
+  /// [recordedDurationSeconds] already includes the closed segment, so
+  /// reopening it would count that time twice. Legacy sessions without
+  /// segment or accumulated-duration data are seeded from their original
+  /// wall-clock span before the new segment starts.
+  void resume() {
+    final previousEnd = endTime;
+    if (previousEnd == null) return;
+
+    if (segments.isEmpty) {
+      segments.add(SessionSegment(startTime: startTime, endTime: previousEnd));
+    }
+    _recordedDurationSeconds ??= segments.fold<int>(0, (total, segment) {
+      final segmentEnd = segment.endTime ?? previousEnd;
+      final seconds = segmentEnd.difference(segment.startTime).inSeconds;
+      return total + (seconds > 0 ? seconds : 0);
+    });
+
+    endTime = null;
+    segments.add(SessionSegment(startTime: DateTime.now()));
   }
 
   /// Closes the currently active recording segment.

--- a/lib/features/survey/survey_controller.dart
+++ b/lib/features/survey/survey_controller.dart
@@ -644,9 +644,15 @@ class SurveyController {
       _maxEndTime = DateTime.now().add(Duration(hours: maxDurationHours));
       _autoStopBattery = autoStopBattery;
 
-      // Open a new recording segment. Any previously accumulated time on
-      // the session is preserved via [LiveSession.recordedDurationSeconds].
-      _session?.startSegment();
+      await _notificationService.start(
+        title: _notificationTitle,
+        text: _buildNotificationText(),
+      );
+
+      // Reactivate only after all fallible async setup has completed so the
+      // original session stays untouched if setup fails. LiveSession.resume
+      // always opens a distinct segment and seeds legacy duration tracking.
+      _session!.resume();
       _segmentStart = DateTime.now();
 
       final intervalMs = (1000.0 / inferenceRate).round();
@@ -654,7 +660,6 @@ class SurveyController {
         Duration(milliseconds: intervalMs),
         (_) => _runInference(windowDuration: windowDuration),
       );
-
       _persistTimer = Timer.periodic(
         const Duration(seconds: _persistIntervalSeconds),
         (_) {
@@ -662,15 +667,9 @@ class SurveyController {
           _checkBatteryAutoStop();
         },
       );
-
       _notificationTimer = Timer.periodic(
         const Duration(seconds: _notificationIntervalSeconds),
         (_) => _updateNotification(),
-      );
-
-      await _notificationService.start(
-        title: _notificationTitle,
-        text: _buildNotificationText(),
       );
 
       _state = SurveyState.active;

--- a/lib/features/survey/survey_live_screen.dart
+++ b/lib/features/survey/survey_live_screen.dart
@@ -534,9 +534,23 @@ class _SurveyLiveScreenState extends ConsumerState<SurveyLiveScreen>
     final inferenceRate = ref.read(surveyInferenceRateProvider);
     final confidenceThreshold = ref.read(confidenceThresholdProvider);
     final filterMode = ref.read(speciesFilterModeProvider);
-    final recordingModeStr = ref.read(surveyRecordingModeProvider);
+    // When resuming, keep the session's *original* recording mode and format
+    // rather than the current global setting. This preserves continuity (a
+    // clip-subsampling session stays clips) and guarantees a resumed session
+    // never switches into full-audio recording — which can't be safely
+    // concatenated across a resume, and is why the Continue button is hidden
+    // for full-audio sessions in the first place.
+    final resumeSettings = widget.resumeSession?.settings;
+    var recordingModeStr = ref.read(surveyRecordingModeProvider);
+    var recordingFormat = ref.read(recordingFormatProvider);
+    if (widget.resumeSession != null) {
+      // Legacy resumable sessions have no recording snapshot and no audio
+      // path. Keep them audio-free instead of inheriting a newer global
+      // setting that could create a partial full-session recording.
+      recordingModeStr = resumeSettings?.recordingMode ?? 'off';
+      recordingFormat = resumeSettings?.recordingFormat ?? recordingFormat;
+    }
     final recordingMode = recordingModeFromString(recordingModeStr);
-    final recordingFormat = ref.read(recordingFormatProvider);
     final geoThreshold = ref.read(geoThresholdProvider);
     final gpsInterval = ref.read(surveyGpsIntervalProvider);
     final maxDuration = ref.read(surveyMaxDurationProvider);
@@ -1049,6 +1063,12 @@ class _SurveyStatusBarState extends ConsumerState<_SurveyStatusBar> {
   }
 
   void _startTimer() {
+    // Reflect the current elapsed immediately so a resumed session shows its
+    // accumulated total right away instead of flashing 00:00:00 until the
+    // first tick fires. Assigning without setState is safe here: _startTimer
+    // is only called from initState / didUpdateWidget, both already inside a
+    // build cycle that will render this value.
+    _elapsed = ref.read(surveyControllerProvider).elapsed;
     _timer = Timer.periodic(const Duration(seconds: 1), (_) {
       if (mounted) {
         setState(() {
@@ -1343,11 +1363,15 @@ class _SurveySummaryTab extends ConsumerWidget {
           return b.bestConfidence.compareTo(a.bestConfidence);
         });
 
-    final elapsed = DateTime.now().difference(session!.startTime);
+    // Rate is per minute of *active recording* time, not wall-clock since
+    // start — otherwise a resumed session dilutes the rate with the entire
+    // stopped gap. [LiveSession.duration] already excludes pause/resume gaps
+    // and matches the on-screen elapsed timer.
+    final elapsed = session!.duration;
+    final activeMinutes = elapsed.inMilliseconds / 60000.0;
     final rate =
-        elapsed.inSeconds > 0
-            ? (detections.length / (elapsed.inMinutes.clamp(1, 999999)))
-                .toStringAsFixed(1)
+        activeMinutes > 0
+            ? (detections.length / activeMinutes).toStringAsFixed(1)
             : '0';
 
     return ListView(

--- a/test/features/history/session_export_test.dart
+++ b/test/features/history/session_export_test.dart
@@ -86,6 +86,101 @@ void main() {
       expect(header, contains('Confidence'));
     });
 
+    test('resumed session: Begin Time uses gap-removed audio offset', () {
+      // Run 1: 08:00:00–08:05:00 (300 s recorded). Stopped, then resumed.
+      // Run 2: 08:35:00–08:40:00 (30-minute gap while stopped). A detection
+      // 10 s into run 2 must map to 310 s in the gap-removed recording
+      // (300 s of run 1 + 10 s), NOT 2110 s of wall-clock since start.
+      final start = DateTime.utc(2025, 6, 15, 8, 0, 0);
+      final seg2Start = start.add(const Duration(minutes: 35));
+      final session = LiveSession(
+        id: '2025-06-15T08-00-00',
+        startTime: start,
+        endTime: start.add(const Duration(minutes: 40)),
+        type: SessionType.survey,
+        recordedDurationSeconds: 600,
+        detections: [
+          _det(
+            'Turdus merula',
+            'Eurasian Blackbird',
+            0.95,
+            const Duration(seconds: 10),
+            seg2Start,
+          ),
+        ],
+        settings: SessionSettings(
+          windowDuration: 3,
+          confidenceThreshold: 25,
+          inferenceRate: 1.0,
+          speciesFilterMode: 'off',
+          clipContextSeconds: 0,
+        ),
+        segments: [
+          SessionSegment(
+            startTime: start,
+            endTime: start.add(const Duration(minutes: 5)),
+          ),
+          SessionSegment(
+            startTime: seg2Start,
+            endTime: start.add(const Duration(minutes: 40)),
+          ),
+        ],
+      );
+
+      final table = buildRavenSelectionTable(
+        session,
+        audioFileName: '$_prefix.wav',
+      );
+      final cols = table
+          .split('\n')
+          .where((l) => l.isNotEmpty)
+          .toList()[1]
+          .split('\t');
+
+      expect(cols[4], '310.000'); // Begin Time (gap removed)
+      expect(cols[5], '313.000'); // End Time (310 + 3)
+    });
+
+    test('resumed session: global annotation ends at recorded duration', () {
+      final start = DateTime.utc(2025, 6, 15, 8);
+      final resumedAt = start.add(const Duration(minutes: 35));
+      final session = LiveSession(
+        id: 'resumed',
+        startTime: start,
+        endTime: start.add(const Duration(minutes: 40)),
+        type: SessionType.survey,
+        detections: [
+          DetectionRecord(
+            scientificName: 'Global',
+            commonName: 'Global',
+            confidence: 1,
+            timestamp: start,
+            source: DetectionSource.manualGlobal,
+          ),
+        ],
+        settings: const SessionSettings(
+          windowDuration: 3,
+          confidenceThreshold: 25,
+          inferenceRate: 1,
+          speciesFilterMode: 'off',
+        ),
+        segments: [
+          SessionSegment(
+            startTime: start,
+            endTime: start.add(const Duration(minutes: 5)),
+          ),
+          SessionSegment(
+            startTime: resumedAt,
+            endTime: start.add(const Duration(minutes: 40)),
+          ),
+        ],
+      );
+
+      final cols = buildRavenSelectionTable(session).split('\n')[1].split('\t');
+      expect(cols[4], '0.000');
+      expect(cols[5], '600.000');
+    });
+
     test('empty detections produces header only', () {
       final session = _makeSession();
       final table = buildRavenSelectionTable(session);

--- a/test/features/live/live_session_test.dart
+++ b/test/features/live/live_session_test.dart
@@ -525,6 +525,80 @@ void main() {
       expect(session.segments.single.endTime, isNotNull);
     });
 
+    test('resume opens a distinct segment and keeps accumulated time', () {
+      final start = DateTime(2026, 2, 28, 14, 0);
+      final session = LiveSession(
+        id: 'test',
+        startTime: start,
+        endTime: start.add(const Duration(minutes: 10)),
+        recordedDurationSeconds: 600,
+        settings: testSettings,
+        segments: [
+          SessionSegment(
+            startTime: start,
+            endTime: start.add(const Duration(minutes: 10)),
+          ),
+        ],
+      );
+
+      // Guard: while stopped, startSegment must not reopen anything.
+      session.startSegment();
+      expect(session.segments, hasLength(1));
+
+      session.resume();
+
+      expect(session.segments, hasLength(2));
+      expect(session.segments.last.endTime, isNull);
+      // Duration continues from the accumulated 10 minutes plus the live
+      // segment (a few ms of wall-clock), so it must exceed the base total.
+      expect(
+        session.duration,
+        greaterThanOrEqualTo(const Duration(minutes: 10)),
+      );
+    });
+
+    test('resume never merges a recently closed segment', () {
+      final end = DateTime.now();
+      final start = end.subtract(const Duration(minutes: 10));
+      final session = LiveSession(
+        id: 'test',
+        startTime: start,
+        endTime: end,
+        recordedDurationSeconds: 600,
+        settings: testSettings,
+        segments: [SessionSegment(startTime: start, endTime: end)],
+      );
+
+      session.resume();
+
+      expect(session.segments, hasLength(2));
+      expect(session.segments.first.endTime, end);
+      expect(session.segments.last.startTime, isNot(start));
+      expect(session.segments.last.endTime, isNull);
+    });
+
+    test('resume seeds timing for a legacy session', () {
+      final start = DateTime(2026, 2, 28, 14, 0);
+      final end = start.add(const Duration(minutes: 10));
+      final session = LiveSession(
+        id: 'legacy',
+        startTime: start,
+        endTime: end,
+        settings: testSettings,
+      );
+
+      session.resume();
+
+      expect(session.recordedDurationSeconds, 600);
+      expect(session.segments, hasLength(2));
+      expect(session.segments.first.startTime, start);
+      expect(session.segments.first.endTime, end);
+      expect(
+        session.duration,
+        greaterThanOrEqualTo(const Duration(minutes: 10)),
+      );
+    });
+
     test('toJson closes stale open segment for ended session', () {
       final start = DateTime(2026, 2, 28, 14, 0);
       final end = start.add(const Duration(minutes: 10));


### PR DESCRIPTION
Ensure that resuming a survey preserves the active timing and correctly aligns audio offsets in exports. This addresses issues with the elapsed timer freezing and ensures detection timestamps match the actual recorded audio.