### PR TITLE
Save detection clips based on peak scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.3] - 2026-07-29
+
+### Fixed
+
+- Detection clips now come from the strongest part of a detection instead of its first moment. A detection lasts as long as the species keeps being heard — often many analysis windows — but a clip holds one window, and the app was always keeping the first one. Since birds typically enter just above the confidence threshold and peak a few seconds later, the saved audio was usually the weakest evidence of the detection and did not match the confidence shown next to it. The clip is now re-cut whenever a detection reaches a noticeably higher score, so what you end up with is the best window the app heard. This also makes **Top N** and **Smart** clip subsampling keep the right clips, since they rank detections by that peak score. Use the clip padding setting to keep more audio around the window. Live, Survey and ARU deployments all follow the same rule, and when several species peak in the same moment their clips are now all cut from that moment instead of drifting later one by one — which is what ARU deployments used to do on a busy dawn chorus.
+- Session Review now shows the right times for clip-only sessions. A detection can run for half a minute while the clip saved for it holds a single analysis window plus your clip padding — so the start-to-end time on each row was describing the bird, not the audio, and the two no longer lined up once clips started following the strongest moment. Rows in sessions without a full recording now show the span the clip actually covers, and the full time the species was heard moved to the detection's player sheet, where it can't be mistaken for the clip length. Sessions with a full recording are unchanged. This also corrects the detection offsets written into Raven and CSV exports for clip-only sessions, which had been pointing at the moment the bird was first heard rather than the moment the clip was cut. Older clips without peak metadata stay anchored to the first detection window.
+- Every detection now owns its own clip file. When several species appeared in the same moment they used to share a single file, so **Top N** and **Smart** subsampling could delete a clip that another detection still pointed at, leaving that detection with a broken play button. A species that was already being heard could also pick up a clip that had been cut for a different species entirely. Both are fixed. The trade-off is more audio on disk when many species are heard at once — subsampling still trims it back at the end of a detection.
+
 ## [0.19.2] - 2026-07-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
    <img src="https://img.shields.io/badge/flutter-%3E%3D3.27-blue.svg" alt="Flutter >=3.27">
   <img src="https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Windows-green.svg" alt="Platforms">
-  <img src="https://img.shields.io/badge/version-0.19.2-orange.svg" alt="Version">
+  <img src="https://img.shields.io/badge/version-0.19.3-orange.svg" alt="Version">
   <img src="https://img.shields.io/badge/species-9%2C789-brightgreen.svg" alt="Species: 9,789">
 </p>
 

--- a/docs/index.cs.md
+++ b/docs/index.cs.md
@@ -5,7 +5,7 @@
 BirdNET Live je aplikace ve Flutteru určená terénním výzkumníkům, ochráncům přírody a pozorovatelům ptáků, kteří v terénu potřebují spolehlivé akustické důkazy. Audio klasifikátor BirdNET+ i geomodel běží přímo ve vašem zařízení, takže identifikace druhů funguje po instalaci zcela offline.
 
 <p align="center">
-  <img src="https://img.shields.io/badge/latest-v0.19.2-orange.svg" alt="Latest release: v0.19.2">
+  <img src="https://img.shields.io/badge/latest-v0.19.3-orange.svg" alt="Latest release: v0.19.3">
   <img src="https://img.shields.io/badge/species-9%2C789-brightgreen.svg" alt="Species: 9,789">
   <img src="https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Windows-green.svg" alt="Platforms">
 </p>

--- a/docs/index.de.md
+++ b/docs/index.de.md
@@ -5,7 +5,7 @@
 BirdNET Live ist eine Flutter-App für Feldforschende, im Naturschutz Tätige und Vogelbegeisterte, die im Feld auf verlässliche akustische Nachweise angewiesen sind. Der BirdNET+ Audio-Klassifikator und das Geo-Modell laufen direkt auf Ihrem Gerät, sodass die Artbestimmung nach der Installation vollständig offline funktioniert.
 
 <p align="center">
-  <img src="https://img.shields.io/badge/latest-v0.19.2-orange.svg" alt="Latest release: v0.19.2">
+  <img src="https://img.shields.io/badge/latest-v0.19.3-orange.svg" alt="Latest release: v0.19.3">
   <img src="https://img.shields.io/badge/species-9%2C789-brightgreen.svg" alt="Species: 9,789">
   <img src="https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Windows-green.svg" alt="Platforms">
 </p>

--- a/docs/index.es.md
+++ b/docs/index.es.md
@@ -5,7 +5,7 @@
 BirdNET Live es una app de Flutter creada para investigadores de campo, conservacionistas y observadores de aves que necesitan evidencia acústica fiable sobre el terreno. Ejecuta el clasificador de audio y el geomodelo de BirdNET+ directamente en tu dispositivo, de modo que la identificación de especies funciona completamente sin conexión una vez instalada.
 
 <p align="center">
-  <img src="https://img.shields.io/badge/latest-v0.19.2-orange.svg" alt="Latest release: v0.19.2">
+  <img src="https://img.shields.io/badge/latest-v0.19.3-orange.svg" alt="Latest release: v0.19.3">
   <img src="https://img.shields.io/badge/species-9%2C789-brightgreen.svg" alt="Species: 9,789">
   <img src="https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Windows-green.svg" alt="Platforms">
 </p>

--- a/docs/index.fr.md
+++ b/docs/index.fr.md
@@ -5,7 +5,7 @@
 BirdNET Live est une application Flutter conçue pour les chercheurs de terrain, les naturalistes et les ornithologues amateurs qui ont besoin de preuves acoustiques fiables sur le terrain. Elle exécute le classifieur audio BirdNET+ et le géo-modèle directement sur votre appareil : l'identification des espèces fonctionne donc entièrement hors ligne une fois l'application installée.
 
 <p align="center">
-  <img src="https://img.shields.io/badge/latest-v0.19.2-orange.svg" alt="Latest release: v0.19.2">
+  <img src="https://img.shields.io/badge/latest-v0.19.3-orange.svg" alt="Latest release: v0.19.3">
   <img src="https://img.shields.io/badge/species-9%2C789-brightgreen.svg" alt="Species: 9,789">
   <img src="https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Windows-green.svg" alt="Platforms">
 </p>

--- a/docs/index.it.md
+++ b/docs/index.it.md
@@ -5,7 +5,7 @@
 BirdNET Live è un'app Flutter pensata per chi fa ricerca sul campo, per chi si occupa di conservazione e per il birdwatching, e ha bisogno di prove acustiche affidabili sul campo. Esegue il classificatore audio BirdNET+ e il geo-modello direttamente sul dispositivo, quindi l'identificazione delle specie funziona completamente offline una volta installata.
 
 <p align="center">
-  <img src="https://img.shields.io/badge/latest-v0.19.2-orange.svg" alt="Latest release: v0.19.2">
+  <img src="https://img.shields.io/badge/latest-v0.19.3-orange.svg" alt="Latest release: v0.19.3">
   <img src="https://img.shields.io/badge/species-9%2C789-brightgreen.svg" alt="Species: 9,789">
   <img src="https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Windows-green.svg" alt="Platforms">
 </p>

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
 BirdNET Live is a Flutter app built for field researchers, conservationists, and birders who need dependable acoustic evidence in the field. It runs the BirdNET+ audio classifier and geo-model directly on your device, so species identification works fully offline once installed.
 
 <p align="center">
-  <img src="https://img.shields.io/badge/latest-v0.19.2-orange.svg" alt="Latest release: v0.19.2">
+  <img src="https://img.shields.io/badge/latest-v0.19.3-orange.svg" alt="Latest release: v0.19.3">
   <img src="https://img.shields.io/badge/species-9%2C789-brightgreen.svg" alt="Species: 9,789">
   <img src="https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Windows-green.svg" alt="Platforms">
 </p>

--- a/docs/index.pt.md
+++ b/docs/index.pt.md
@@ -5,7 +5,7 @@
 O BirdNET Live é um aplicativo Flutter desenvolvido para pesquisadores de campo, profissionais de conservação e observadores de aves que precisam de evidências acústicas confiáveis em campo. Ele executa o classificador de áudio BirdNET+ e o geomodelo diretamente no seu dispositivo, de modo que a identificação de espécies funciona totalmente offline depois de instalado.
 
 <p align="center">
-  <img src="https://img.shields.io/badge/latest-v0.19.2-orange.svg" alt="Latest release: v0.19.2">
+  <img src="https://img.shields.io/badge/latest-v0.19.3-orange.svg" alt="Latest release: v0.19.3">
   <img src="https://img.shields.io/badge/species-9%2C789-brightgreen.svg" alt="Species: 9,789">
   <img src="https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Windows-green.svg" alt="Platforms">
 </p>

--- a/integration_test/aru_deployment_test.dart
+++ b/integration_test/aru_deployment_test.dart
@@ -202,25 +202,32 @@ void main() {
         '${sandbox.path}/clips',
       ).create(recursive: true);
 
-      // Real clip saver: writes a small file and returns its path, mirroring
-      // the detections-only retention path.
-      Future<String?> saveClip(
+      // Real clip saver: writes a small file per record in the round and
+      // returns their paths, mirroring the detections-only retention path.
+      Future<Map<DetectionRecord, String>> saveClips(
         LiveSession session,
-        DetectionRecord record,
+        List<DetectionRecord> records,
       ) async {
-        final safeTs = record.timestamp.toIso8601String().replaceAll(':', '-');
-        final path =
-            '${clipsDir.path}/clip_${record.scientificName}_$safeTs.wav';
-        await File(path).writeAsBytes(
-          List<int>.filled(64, 0),
-          flush: true,
-        );
-        return path;
+        final written = <DetectionRecord, String>{};
+        for (final record in records) {
+          final safeTs = record.timestamp.toIso8601String().replaceAll(
+                ':',
+                '-',
+              );
+          final path =
+              '${clipsDir.path}/clip_${record.scientificName}_$safeTs.wav';
+          await File(path).writeAsBytes(
+            List<int>.filled(64, 0),
+            flush: true,
+          );
+          written[record] = path;
+        }
+        return written;
       }
 
       final controller = AruController(
         saveSession: repository.save,
-        saveDetectionClip: saveClip,
+        saveDetectionClips: saveClips,
         now: () => scheduleStart.subtract(const Duration(minutes: 5)),
       );
 

--- a/lib/features/aru/aru_controller.dart
+++ b/lib/features/aru/aru_controller.dart
@@ -39,9 +39,18 @@ typedef AruCycleRecordingStopper =
       DateTime endedAt,
     );
 
-/// Saves a detection-only clip while an ARU cycle is recording.
+/// Cuts detection-only clips for a batch of records while a cycle is
+/// recording, all from the same slice of audio.
+///
+/// Batched rather than per-record so a sync round costs one post-roll wait and
+/// anchors every clip in the round to the same moment — the Live and Survey
+/// inference loops cut their clips the same way. Returns the written path per
+/// record; records whose clip could not be written are absent from the map.
 typedef AruDetectionClipSaver =
-    Future<String?> Function(LiveSession session, DetectionRecord record);
+    Future<Map<DetectionRecord, String>> Function(
+      LiveSession session,
+      List<DetectionRecord> records,
+    );
 
 /// Minimal ARU controller that owns schedule transitions and session metadata.
 ///
@@ -54,20 +63,20 @@ class AruController {
     AruSessionDiscarder? discardSession,
     AruCycleRecordingStarter? startCycleRecording,
     AruCycleRecordingStopper? stopCycleRecording,
-    AruDetectionClipSaver? saveDetectionClip,
+    AruDetectionClipSaver? saveDetectionClips,
     DateTime Function()? now,
   }) : _saveSession = saveSession,
        _discardSession = discardSession,
        _startCycleRecording = startCycleRecording,
        _stopCycleRecording = stopCycleRecording,
-       _saveDetectionClip = saveDetectionClip,
+       _saveDetectionClips = saveDetectionClips,
        _now = now ?? DateTime.now;
 
   final AruSessionSaver _saveSession;
   final AruSessionDiscarder? _discardSession;
   final AruCycleRecordingStarter? _startCycleRecording;
   final AruCycleRecordingStopper? _stopCycleRecording;
-  final AruDetectionClipSaver? _saveDetectionClip;
+  final AruDetectionClipSaver? _saveDetectionClips;
   final DateTime Function() _now;
 
   AruControllerState _state = AruControllerState.idle;
@@ -77,6 +86,7 @@ class AruController {
   int? _activeCycleIndex;
   DateTime? _activeCycleStart;
   AruDetectionSampler? _sampler;
+  final DetectionClipPeakTracker _clipPeakTracker = DetectionClipPeakTracker();
   LiveSession? _lastReviewSession;
 
   AruControllerState get state => _state;
@@ -126,6 +136,7 @@ class AruController {
     );
     _activeCycleIndex = null;
     _activeCycleStart = null;
+    _clipPeakTracker.clear();
     _lastReviewSession = session;
     _sampler = AruDetectionSampler(
       mode: samplingModeFromString(session.aruMetadata!.samplingMode),
@@ -156,6 +167,7 @@ class AruController {
     _errorMessage = null;
     _activeCycleIndex = null;
     _activeCycleStart = null;
+    _clipPeakTracker.clear();
 
     try {
       _calculator = AruScheduleCalculator(metadata.toScheduleConfig());
@@ -265,21 +277,71 @@ class AruController {
     final session = _session;
     if (session == null || records.isEmpty) return;
 
-    var changed = false;
-    for (final record in records) {
-      final existingIndex = _detectionIndex(session.detections, record);
-      final existing =
-          existingIndex == -1 ? null : session.detections[existingIndex];
-      final synced = await _syncedDetectionRecord(session, record, existing);
+    // Pass 1 — pair each incoming record with the one already in the session
+    // and work out which of them want a clip cut from the audio available
+    // right now. Deciding up front lets the whole round share one post-roll
+    // wait and one slice of audio, exactly as the Live and Survey inference
+    // loops do it.
+    final pairs = <_DetectionSyncPair>[];
+    final wantsClip = <DetectionRecord>[];
+    final savesClips =
+        recordingModeFromString(
+          session.aruMetadata?.recordingMode ?? RecordingMode.off.name,
+        ) ==
+        RecordingMode.detectionsOnly;
 
-      if (existingIndex == -1) {
+    for (final record in records) {
+      final index = _detectionIndex(session.detections, record);
+      final existing = index == -1 ? null : session.detections[index];
+      pairs.add(_DetectionSyncPair(record, existing, index));
+      if (savesClips && _wantsDetectionClip(record, existing)) {
+        wantsClip.add(record);
+      }
+    }
+
+    // Date the analyzed window before the saver waits for post-roll. Using
+    // the clock after that await shifts the claimed window forward by exactly
+    // the configured clip context.
+    final clipWindowStart = _now().subtract(
+      Duration(seconds: session.settings.windowDuration),
+    );
+    final clips =
+        wantsClip.isEmpty
+            ? const <DetectionRecord, String>{}
+            : await _saveDetectionClips?.call(session, wantsClip) ??
+                const <DetectionRecord, String>{};
+
+    // Pass 2 — apply. `addDetection` appends, so the indices captured above
+    // still point at the same records.
+    var changed = false;
+    final supersededClipPaths = <String>[];
+    for (final pair in pairs) {
+      final synced = await _syncedDetectionRecord(pair, clips, clipWindowStart);
+
+      if (pair.index == -1) {
         session.addDetection(synced);
         changed = true;
-      } else if (!_sameDetectionPayload(existing!, synced)) {
-        session.detections[existingIndex] = synced;
-        _sampler?.replaceRecord(existing, synced);
+      } else if (!_sameDetectionPayload(pair.existing!, synced)) {
+        session.detections[pair.index] = synced;
+        _sampler?.replaceRecord(pair.existing!, synced);
         changed = true;
       }
+      final fresh = clips[pair.record];
+      final previous = pair.existing?.audioClipPath;
+      if (fresh != null) {
+        _clipPeakTracker.recordSaved(
+          _detectionClipKey(pair.record),
+          pair.record.confidence,
+        );
+        if (previous != null && previous != fresh) {
+          supersededClipPaths.add(previous);
+        }
+      }
+    }
+    // Every session record points at its fresh file before deletion can yield
+    // to cycle finalization.
+    for (final path in supersededClipPaths) {
+      await deleteDetectionClipFile(path, logTag: 'AruController');
     }
     if (!changed) return;
 
@@ -287,29 +349,53 @@ class AruController {
     await _persist();
   }
 
-  Future<DetectionRecord> _syncedDetectionRecord(
-    LiveSession session,
-    DetectionRecord record,
-    DetectionRecord? existing,
-  ) async {
-    var audioClipPath = existing?.audioClipPath ?? record.audioClipPath;
-    final isNew = existing == null;
+  /// Whether [record] wants a clip cut from the audio in the ring buffer now.
+  ///
+  /// Only while the detection is still open: once the species has stopped
+  /// vocalizing the buffer holds later, unrelated audio. Beyond that the
+  /// decision is [DetectionClipPeakTracker.needsClip]'s — the same rule Live
+  /// and Survey apply.
+  bool _wantsDetectionClip(DetectionRecord record, DetectionRecord? existing) {
     final closesNow =
         record.endTimestamp != null && existing?.endTimestamp == null;
-    final mode = recordingModeFromString(
-      session.aruMetadata?.recordingMode ?? RecordingMode.off.name,
+    if (existing != null && (closesNow || existing.endTimestamp != null)) {
+      return false;
+    }
+    return _clipPeakTracker.needsClip(
+      key: _detectionClipKey(record),
+      candidateConfidence: record.confidence,
+      currentConfidence: existing?.confidence ?? record.confidence,
+      hasClip: (existing?.audioClipPath ?? record.audioClipPath) != null,
+      isNew: existing == null,
     );
+  }
 
-    // Save the detection clip the moment the species first appears, while the
-    // analyzed audio is still fresh in the ring buffer — matching how Live and
-    // Survey capture clips. Saving at close time (after the species had already
-    // disappeared) grabbed unrelated, later audio, producing clips that did not
-    // contain the detected species; the cycle's recording could also have
-    // stopped by then, yielding no clip at all.
-    if (isNew &&
-        mode == RecordingMode.detectionsOnly &&
-        audioClipPath == null) {
-      audioClipPath = await _saveDetectionClip?.call(session, record);
+  Future<DetectionRecord> _syncedDetectionRecord(
+    _DetectionSyncPair pair,
+    Map<DetectionRecord, String> clips,
+    DateTime clipWindowStart,
+  ) async {
+    final record = pair.record;
+    final existing = pair.existing;
+    var audioClipPath = existing?.audioClipPath ?? record.audioClipPath;
+    var clipTimestamp = existing?.clipTimestamp ?? record.clipTimestamp;
+    final clipKey = _detectionClipKey(record);
+    final closesNow =
+        record.endTimestamp != null && existing?.endTimestamp == null;
+
+    // A clip is cut the moment the species first appears — while the analyzed
+    // audio is still fresh in the ring buffer — and re-cut whenever the
+    // detection reaches a new confidence peak. A merged detection spans many
+    // windows but a clip holds one, and the first window is typically its
+    // weakest, so the clip has to follow the peak.
+    final fresh = clips[record];
+    if (fresh != null) {
+      audioClipPath = fresh;
+      clipTimestamp = clipWindowStart;
+    } else if (existing == null && audioClipPath != null) {
+      // Arrived with a clip already attached: adopt its score as the baseline
+      // so later peaks are measured against the audio actually on disk.
+      _clipPeakTracker.recordSaved(clipKey, record.confidence);
     }
 
     final synced = DetectionRecord(
@@ -322,6 +408,7 @@ class AruController {
       timestamp: record.timestamp,
       endTimestamp: record.endTimestamp ?? existing?.endTimestamp,
       audioClipPath: audioClipPath,
+      clipTimestamp: audioClipPath == null ? null : clipTimestamp,
       source: record.source,
       latitude: record.latitude ?? existing?.latitude,
       longitude: record.longitude ?? existing?.longitude,
@@ -332,6 +419,7 @@ class AruController {
 
     if (closesNow) {
       await _sampler?.onRecordClosed(synced);
+      _clipPeakTracker.forget(clipKey);
     }
 
     return synced;
@@ -345,6 +433,10 @@ class AruController {
     );
   }
 
+  String _detectionClipKey(DetectionRecord record) =>
+      '${record.scientificName}\u0000'
+      '${record.timestamp.microsecondsSinceEpoch}';
+
   bool _sameDetectionPayload(DetectionRecord a, DetectionRecord b) {
     return a.scientificName == b.scientificName &&
         a.commonName == b.commonName &&
@@ -352,6 +444,7 @@ class AruController {
         a.timestamp == b.timestamp &&
         a.endTimestamp == b.endTimestamp &&
         a.audioClipPath == b.audioClipPath &&
+        a.clipTimestamp == b.clipTimestamp &&
         a.latitude == b.latitude &&
         a.longitude == b.longitude &&
         a.confirmedAt == b.confirmedAt &&
@@ -799,4 +892,17 @@ class AruController {
   bool _isTestCycle(LiveSession session, int cycleIndex) {
     return session.aruMetadata?.testCycleEnabled == true && cycleIndex == 0;
   }
+}
+
+/// An incoming detection paired with the session record it updates.
+///
+/// Resolved once per sync round so the clip decision and the record rebuild
+/// agree on the pairing without scanning the session twice. [index] is `-1`
+/// when the detection is new to the session.
+class _DetectionSyncPair {
+  _DetectionSyncPair(this.record, this.existing, this.index);
+
+  final DetectionRecord record;
+  final DetectionRecord? existing;
+  final int index;
 }

--- a/lib/features/aru/aru_detection_sampler.dart
+++ b/lib/features/aru/aru_detection_sampler.dart
@@ -151,6 +151,9 @@ class AruDetectionSampler {
   Future<void> _evictClip(DetectionRecord record) async {
     final path = record.audioClipPath;
     record.audioClipPath = null;
+    // The window the clip was cut from describes a file that no longer
+    // exists; clearing it keeps the record from advertising audio it lost.
+    record.clipTimestamp = null;
     _droppedClipCount++;
     await deleteDetectionClipFile(path, logTag: 'AruDetectionSampler');
   }

--- a/lib/features/aru/aru_providers.dart
+++ b/lib/features/aru/aru_providers.dart
@@ -121,14 +121,14 @@ final aruControllerProvider = Provider<AruController>((ref) {
       aruCaptureActive = !captureWasRunning;
       return path;
     },
-    saveDetectionClip: (session, record) async {
-      final timestamp = record.timestamp.toUtc().millisecondsSinceEpoch;
-      final safeName = record.scientificName.replaceAll(
-        RegExp(r'[^A-Za-z0-9_-]+'),
-        '_',
-      );
-      return recordingService.saveDetectionClip(
-        clipName: 'clip_${timestamp}_$safeName',
+    saveDetectionClips: (session, records) {
+      // Clip names come from the save time, not the detection time, so
+      // re-cutting a detection's clip at a stronger window writes a new file
+      // instead of overwriting the only copy in place.
+      return saveDetectionClipsFor<DetectionRecord>(
+        recordingService: recordingService,
+        items: records,
+        speciesOf: (record) => record.scientificName,
       );
     },
     stopCycleRecording: (session, cycle, endedAt) async {

--- a/lib/features/file_analysis/file_analysis_controller.dart
+++ b/lib/features/file_analysis/file_analysis_controller.dart
@@ -550,6 +550,7 @@ class FileAnalysisController {
               timestamp: existing.timestamp,
               endTimestamp: windowEnd,
               audioClipPath: existing.audioClipPath,
+              clipTimestamp: existing.clipTimestamp,
               source: existing.source,
               latitude: existing.latitude,
               longitude: existing.longitude,

--- a/lib/features/history/services/detection_audio_window.dart
+++ b/lib/features/history/services/detection_audio_window.dart
@@ -18,6 +18,9 @@ DetectionAudioWindow detectionAudioWindow(
   LiveSession session,
   DetectionRecord detection, {
   double? clipContextSeconds,
+  // Export staging can reference a detection clip by index even when the
+  // record's original path is not attached to the in-memory test/copy.
+  bool? referencesDetectionClip,
 }) {
   final context = math.max(0.0, clipContextSeconds ?? 0.0);
   // Offset into the *recorded* audio timeline, which is a gap-removed
@@ -27,15 +30,39 @@ DetectionAudioWindow detectionAudioWindow(
   // sessions (no segments) this reduces to timestamp - startTime.
   final start = session.absoluteToRelative(detection.timestamp);
   final duration = detectionDurationSeconds(detection, session.settings);
-  final clipStart = math.max(0.0, start - context);
-  final detectionStartInClip = start - clipStart;
+
+  // Where the clip file itself sits. A detection-clip session holds one
+  // analysis window per record, re-cut as the detection climbed to its
+  // confidence peak, so the clip generally starts well after the detection
+  // did — anchoring it at [DetectionRecord.timestamp] would misplace the
+  // detection inside the clip in Raven/CSV exports. Records without a
+  // [DetectionRecord.clipTimestamp] predate peak-following clips and were
+  // cut on arrival, so the detection start is their correct anchor.
+  final clipWindowStart = detection.clipTimestamp;
+  final clipAnchor =
+      clipWindowStart == null
+          ? start
+          : session.absoluteToRelative(clipWindowStart);
+  // A per-detection clip has always held exactly one analysis window plus its
+  // padding, including legacy clips without a peak timestamp. Full-recording
+  // extraction still uses the complete detection span.
+  final hasDetectionClip =
+      referencesDetectionClip ?? (detection.audioClipPath ?? '').isNotEmpty;
+  final clipWindowDuration =
+      hasDetectionClip ? session.settings.windowDuration.toDouble() : duration;
+
+  final clipStart = math.max(0.0, clipAnchor - context);
+  // Detection clip files keep their zero-padded pre-roll even when the
+  // analysis window begins at the session boundary.
+  final detectionStartInClip =
+      hasDetectionClip ? context : clipAnchor - clipStart;
   return DetectionAudioWindow(
     detectionStartSec: start,
     detectionDurationSec: duration,
     clipStartSec: clipStart,
-    clipDurationSec: duration + context * 2,
+    clipDurationSec: clipWindowDuration + context * 2,
     clipDetectionStartSec: detectionStartInClip,
-    clipDetectionEndSec: detectionStartInClip + duration,
+    clipDetectionEndSec: detectionStartInClip + clipWindowDuration,
   );
 }
 

--- a/lib/features/history/services/detection_sharing_service.dart
+++ b/lib/features/history/services/detection_sharing_service.dart
@@ -201,6 +201,7 @@ Future<File?> _extractClipFromFullAudio(
     session,
     detection,
     clipContextSeconds: session.settings.clipContextSeconds.toDouble(),
+    referencesDetectionClip: false,
   );
 
   final ext = await sourceAudioExtensionForFile(src);

--- a/lib/features/history/session_export.dart
+++ b/lib/features/history/session_export.dart
@@ -278,6 +278,7 @@ String buildRavenSelectionTable(
       session,
       d,
       clipContextSeconds: clipContext,
+      referencesDetectionClip: referencesClip,
     );
     // Session-relative offset (always computed; used for either Begin Time
     // or the auxiliary Survey Time column), rebased onto the exported
@@ -420,6 +421,7 @@ String buildCsvExport(
       session,
       d,
       clipContextSeconds: clipContext,
+      referencesDetectionClip: referencesClip,
     );
     // Session-relative offset, rebased onto the exported (possibly trimmed)
     // audio so it indexes the file the row references.

--- a/lib/features/history/session_review_screen.dart
+++ b/lib/features/history/session_review_screen.dart
@@ -2257,11 +2257,13 @@ class _SessionReviewScreenState extends ConsumerState<SessionReviewScreen> {
     // has clip files but no recorded context value, fall back to the
     // device's current survey clip-context preference.
     final sessionClipContext = widget.session.settings.clipContextSeconds;
-    final hasClips = widget.session.detections.any(
+    final clips = widget.session.detections.where(
       (d) => d.audioClipPath != null && d.audioClipPath!.isNotEmpty,
     );
+    final hasOnlyLegacyClips =
+        clips.isNotEmpty && clips.every((d) => d.clipTimestamp == null);
     final clipContextOverride =
-        (hasClips && sessionClipContext == 0)
+        (hasOnlyLegacyClips && sessionClipContext == 0)
             ? ref.read(surveyClipContextProvider)
             : null;
 
@@ -2371,7 +2373,9 @@ class _SessionReviewScreenState extends ConsumerState<SessionReviewScreen> {
                 commonName: result.commonName,
                 confidence: result.replaceRecord!.confidence,
                 timestamp: result.replaceRecord!.timestamp,
+                endTimestamp: result.replaceRecord!.endTimestamp,
                 audioClipPath: result.replaceRecord!.audioClipPath,
+                clipTimestamp: result.replaceRecord!.clipTimestamp,
                 source:
                     result.userSpecified
                         ? DetectionSource.userSpecified
@@ -2379,6 +2383,8 @@ class _SessionReviewScreenState extends ConsumerState<SessionReviewScreen> {
                 confirmedAt: result.replaceRecord!.confirmedAt,
                 note: result.replaceRecord!.note,
                 voiceMemoPath: result.replaceRecord!.voiceMemoPath,
+                latitude: result.replaceRecord!.latitude,
+                longitude: result.replaceRecord!.longitude,
               );
             }
           }
@@ -3655,7 +3661,9 @@ class _SessionReviewScreenState extends ConsumerState<SessionReviewScreen> {
             commonName: result.commonName,
             confidence: result.replaceRecord!.confidence,
             timestamp: result.replaceRecord!.timestamp,
+            endTimestamp: result.replaceRecord!.endTimestamp,
             audioClipPath: result.replaceRecord!.audioClipPath,
+            clipTimestamp: result.replaceRecord!.clipTimestamp,
             source:
                 result.userSpecified
                     ? DetectionSource.userSpecified
@@ -3663,6 +3671,8 @@ class _SessionReviewScreenState extends ConsumerState<SessionReviewScreen> {
             confirmedAt: result.replaceRecord!.confirmedAt,
             note: result.replaceRecord!.note,
             voiceMemoPath: result.replaceRecord!.voiceMemoPath,
+            latitude: result.replaceRecord!.latitude,
+            longitude: result.replaceRecord!.longitude,
           );
         }
       }

--- a/lib/features/history/widgets/clip_player_sheet.dart
+++ b/lib/features/history/widgets/clip_player_sheet.dart
@@ -196,8 +196,10 @@ class _ClipPlayerSheetState extends ConsumerState<_ClipPlayerSheet> {
         _decoding = false;
       });
     } catch (e, st) {
-      debugPrint('[ClipPlayerSheet] spectrogram decode failed for '
-          '${widget.clipPath}: $e\n$st');
+      debugPrint(
+        '[ClipPlayerSheet] spectrogram decode failed for '
+        '${widget.clipPath}: $e\n$st',
+      );
       if (mounted) setState(() => _decoding = false);
     }
   }
@@ -439,9 +441,18 @@ class _ClipPlayerSheetState extends ConsumerState<_ClipPlayerSheet> {
             ?.lookup(det.scientificName)
             ?.commonNameForLocale(speciesLocale) ??
         det.commonName;
-    final timeStr = DateFormat(
-      'yyyy-MM-dd HH:mm:ss',
-    ).format(det.timestamp.toLocal());
+    // When the species stayed above threshold for longer than one analysis
+    // window, show the whole span the bird was heard for. The review row's
+    // range describes the clip — one window plus padding, cut at the peak —
+    // so this is the one place the full vocalization is still visible, and
+    // nothing here implies it is the length of the audio below.
+    final detStart = det.timestamp.toLocal();
+    final detEnd = det.endTimestamp?.toLocal();
+    final startStr = DateFormat('yyyy-MM-dd HH:mm:ss').format(detStart);
+    final timeStr =
+        detEnd != null && detEnd.isAfter(detStart)
+            ? '$startStr – ${DateFormat('HH:mm:ss').format(detEnd)}'
+            : startStr;
     // Use the unified [ScoreColors] CVD-safe ramp so the avatar border on
     // this sheet matches the same detection's marker on the survey map and
     // its pill color in the Explore list.

--- a/lib/features/history/widgets/session_review_widgets.dart
+++ b/lib/features/history/widgets/session_review_widgets.dart
@@ -2031,6 +2031,43 @@ class _ClusterRow extends ConsumerWidget {
   final bool audioAvailable;
   final VoidCallback? onShowOnMap;
 
+  /// Wall-clock span of this cluster's detection clip, or null when the row
+  /// should show the detection span instead.
+  ///
+  /// Returns null for sessions with a full recording (where the detection
+  /// span lines up with audio the user can actually scrub) and for clusters
+  /// with no clip of their own.
+  ///
+  /// The span is `clipContext + windowDuration + clipContext` around the
+  /// analysis window the clip was cut from, so it matches the file byte for
+  /// byte. Records saved before clips followed the confidence peak have no
+  /// [DetectionRecord.clipTimestamp]; those clips were cut on arrival, so
+  /// the detection start is their correct anchor.
+  (DateTime, DateTime)? _clipTimeRange(WidgetRef ref) {
+    if (audioAvailable) return null;
+    final clipRecord =
+        cluster.records
+            .where((r) => (r.audioClipPath ?? '').isNotEmpty)
+            .firstOrNull;
+    if (clipRecord == null) return null;
+
+    // Mirrors the export path: a session with clips but no recorded context
+    // value predates the setting, so fall back to the current preference
+    // rather than claiming zero padding.
+    final recorded = session.settings.clipContextSeconds;
+    final context =
+        recorded == 0 && clipRecord.clipTimestamp == null
+            ? ref.watch(surveyClipContextProvider)
+            : recorded;
+
+    final windowStart = clipRecord.clipTimestamp ?? clipRecord.timestamp;
+    final clipStart = windowStart.subtract(Duration(seconds: context));
+    return (
+      clipStart,
+      clipStart.add(Duration(seconds: context * 2 + windowSec)),
+    );
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
@@ -2047,12 +2084,24 @@ class _ClusterRow extends ConsumerWidget {
     final lastEnd =
         lastRecord.endTimestamp ??
         lastRecord.timestamp.add(Duration(seconds: windowSec));
+
+    // When the only audio is per-detection clips, the row's range has to
+    // describe the *clip*, not the detection. A detection can run for
+    // half a minute while its clip holds one analysis window plus padding,
+    // cut wherever the detection peaked — so a detection span here would
+    // advertise audio the file does not contain. [_clipTimeRange] returns
+    // null for full-recording sessions and for clusters without a clip,
+    // where the detection span is the honest answer.
+    final clipRange = _clipTimeRange(ref);
+    final rangeStart = clipRange?.$1 ?? cluster.firstTimestamp;
+    final rangeEnd = clipRange?.$2 ?? lastEnd;
+
     // Always show the full span (start – end) so users can see the
     // duration of continuous detections at a glance. For very short
     // detections where the formatted strings would be identical, fall
     // back to a single timestamp to keep the row compact.
     final startStr = formatDetectionTime(
-      cluster.firstTimestamp,
+      rangeStart,
       session.startTime,
       tsMode,
       absoluteToRelative: session.absoluteToRelative,
@@ -2062,7 +2111,7 @@ class _ClusterRow extends ConsumerWidget {
       alwaysUse24HourFormat: MediaQuery.of(context).alwaysUse24HourFormat,
     );
     final endStr = formatDetectionTime(
-      lastEnd,
+      rangeEnd,
       session.startTime,
       tsMode,
       absoluteToRelative: session.absoluteToRelative,

--- a/lib/features/live/live_controller.dart
+++ b/lib/features/live/live_controller.dart
@@ -178,6 +178,13 @@ class LiveController {
   /// detected.
   final Map<String, DetectionRecord> _activeCardSpecies = {};
 
+  /// Confidence of the audio window currently saved for each active species.
+  ///
+  /// This deliberately differs from [DetectionRecord.confidence], which is the
+  /// running maximum and advances even when an improvement is below the clip
+  /// rewrite threshold.
+  final DetectionClipPeakTracker _clipPeakTracker = DetectionClipPeakTracker();
+
   /// Maximum number of in-memory detections (older entries are still
   /// persisted in the [LiveSession] object).
   static const int _maxInMemoryDetections = 1000;
@@ -437,6 +444,7 @@ class LiveController {
     _latestDetections = const [];
     _currentLiveDetections = const [];
     _activeCardSpecies.clear();
+    _clipPeakTracker.clear();
     _sessionGeneration++;
     _confidenceThreshold = confidenceThreshold;
     _sensitivity = sensitivity;
@@ -604,6 +612,7 @@ class LiveController {
     _latestDetections = const [];
     _currentLiveDetections = const [];
     _activeCardSpecies.clear();
+    _clipPeakTracker.clear();
 
     _state = LiveState.ready;
     _notifyListeners();
@@ -799,6 +808,7 @@ class LiveController {
         final now = DateTime.now();
         for (final name in disappeared) {
           final existing = _activeCardSpecies.remove(name);
+          _clipPeakTracker.forget(name);
           if (existing == null) continue;
           final closed = _recordWithEnd(existing, now);
           final sessionIdx = _sessionDetections.indexOf(existing);
@@ -807,14 +817,33 @@ class LiveController {
           if (lsIdx != -1) _session!.detections[lsIdx] = closed;
         }
 
-        // Save detection clip if user requested per-detection clips
-        // and there are new species appearing.
-        String? clipPath;
-        if (_saveDetectionClips && appeared.isNotEmpty) {
-          final clipName = 'clip_${DateTime.now().millisecondsSinceEpoch}';
-          clipPath = await recordingService.saveDetectionClip(
-            clipName: clipName,
-          );
+        // Save detection clips if the user requested per-detection clips.
+        //
+        // A clip is cut for a species that just appeared, and re-cut whenever
+        // an ongoing detection reaches a new confidence peak. A merged
+        // detection can span many windows, but a clip only holds one — so the
+        // one we keep must be the strongest window, not the first. Species
+        // entering at the confidence floor and peaking a few cycles later is
+        // the common case, which is exactly what the first window gets wrong.
+        //
+        // All clips for this cycle are cut from a single ring-buffer read, so
+        // a busy cycle costs one post-roll wait rather than one per species.
+        final clipPaths = await _saveCycleClips(
+          filteredDetections,
+          appeared: appeared,
+        );
+
+        // The post-roll wait inside the clip save is the one point in a cycle
+        // where the session can be torn down underneath us: finalize, pause
+        // and reset all bump the generation before their own awaits. Without
+        // this check the records below would be attached to a session that is
+        // already closed, and a re-cut would delete a clip that the session's
+        // now-closed record still points at.
+        if (generation != _sessionGeneration || _session == null) {
+          for (final path in clipPaths.values) {
+            await recordingService.deleteClip(path);
+          }
+          return;
         }
 
         for (final detection in filteredDetections) {
@@ -822,27 +851,50 @@ class LiveController {
 
           if (appeared.contains(name)) {
             // New detection — species just appeared in inference.
+            //
+            // Every clip in this cycle came from one ring-buffer read, so
+            // they all hold the window that just ran: `windowTimestamp` dates
+            // the audio for all of them.
             final record = DetectionRecord.fromDetection(
               detection,
-              audioClipPath: clipPath,
+              audioClipPath: clipPaths[name],
+              clipTimestamp: windowTimestamp,
             );
             _session!.addDetection(record);
             _sessionDetections.insert(0, record);
             _activeCardSpecies[name] = record;
+            if (record.audioClipPath != null) {
+              _clipPeakTracker.recordSaved(name, detection.confidence);
+            }
           } else if (_activeCardSpecies.containsKey(name)) {
             // Ongoing — update confidence if higher (same detection).
             final existing = _activeCardSpecies[name]!;
             if (detection.confidence > existing.confidence) {
+              final freshClip = clipPaths[name];
               final updated = _recordWithConfidence(
                 existing,
                 detection.confidence,
-                audioClipPath: existing.audioClipPath ?? clipPath,
+                audioClipPath: freshClip ?? existing.audioClipPath,
+                // A re-cut moves the audio to this cycle's window; keeping
+                // the old clip keeps the window it was cut from.
+                clipTimestamp:
+                    freshClip == null
+                        ? existing.clipTimestamp
+                        : windowTimestamp,
               );
               final sessionIdx = _sessionDetections.indexOf(existing);
               if (sessionIdx != -1) _sessionDetections[sessionIdx] = updated;
               final lsIdx = _session!.detections.indexOf(existing);
               if (lsIdx != -1) _session!.detections[lsIdx] = updated;
               _activeCardSpecies[name] = updated;
+
+              if (freshClip != null) {
+                // Publish the replacement before the first await. Otherwise
+                // pause/finalize can persist the old path after its file has
+                // already been deleted.
+                _clipPeakTracker.recordSaved(name, detection.confidence);
+                await recordingService.deleteClip(existing.audioClipPath);
+              }
             }
           }
         }
@@ -905,6 +957,42 @@ class LiveController {
     _segmentStart = null;
   }
 
+  /// Cut this cycle's detection clips, returning scientific name → clip path.
+  ///
+  /// Which species need one is [DetectionClipPeakTracker.needsClip]'s call —
+  /// the same rule Survey and ARU apply — and they are all cut from a single
+  /// ring-buffer read so the whole cycle costs one post-roll wait.
+  Future<Map<String, String>> _saveCycleClips(
+    List<Detection> detections, {
+    required Set<String> appeared,
+  }) async {
+    if (!_saveDetectionClips) return const {};
+
+    final needsClip = <String>[];
+    for (final detection in detections) {
+      final name = detection.species.scientificName;
+      final isNew = appeared.contains(name);
+      final existing = _activeCardSpecies[name];
+      if (!isNew && existing == null) continue;
+
+      if (_clipPeakTracker.needsClip(
+        key: name,
+        candidateConfidence: detection.confidence,
+        currentConfidence: existing?.confidence ?? detection.confidence,
+        hasClip: existing?.audioClipPath != null,
+        isNew: isNew,
+      )) {
+        needsClip.add(name);
+      }
+    }
+
+    return saveDetectionClipsFor<String>(
+      recordingService: recordingService,
+      items: needsClip,
+      speciesOf: (name) => name,
+    );
+  }
+
   DetectionRecord _recordWithEnd(DetectionRecord existing, DateTime end) {
     return DetectionRecord(
       scientificName: existing.scientificName,
@@ -913,6 +1001,7 @@ class LiveController {
       timestamp: existing.timestamp,
       endTimestamp: end,
       audioClipPath: existing.audioClipPath,
+      clipTimestamp: existing.clipTimestamp,
       source: existing.source,
       latitude: existing.latitude,
       longitude: existing.longitude,
@@ -926,6 +1015,7 @@ class LiveController {
     DetectionRecord existing,
     double confidence, {
     String? audioClipPath,
+    DateTime? clipTimestamp,
   }) {
     return DetectionRecord(
       scientificName: existing.scientificName,
@@ -934,6 +1024,7 @@ class LiveController {
       timestamp: existing.timestamp,
       endTimestamp: existing.endTimestamp,
       audioClipPath: audioClipPath,
+      clipTimestamp: audioClipPath == null ? null : clipTimestamp,
       source: existing.source,
       latitude: existing.latitude,
       longitude: existing.longitude,
@@ -953,6 +1044,7 @@ class LiveController {
     _latestDetections = const [];
     _currentLiveDetections = const [];
     _activeCardSpecies.clear();
+    _clipPeakTracker.clear();
     _notifyListeners();
   }
 

--- a/lib/features/live/live_session.dart
+++ b/lib/features/live/live_session.dart
@@ -352,6 +352,7 @@ class DetectionRecord {
     required this.timestamp,
     this.endTimestamp,
     this.audioClipPath,
+    this.clipTimestamp,
     this.source = DetectionSource.auto,
     this.latitude,
     this.longitude,
@@ -392,6 +393,22 @@ class DetectionRecord {
   /// underlying file) when an audio clip is dropped to enforce per-species
   /// or spatial caps. The detection record itself is always retained.
   String? audioClipPath;
+
+  /// Start of the analysis window [audioClipPath] was cut from.
+  ///
+  /// [timestamp] and [endTimestamp] describe when the *bird* was heard — the
+  /// full span the species stayed above threshold, which is the ecologically
+  /// meaningful number and often far longer than any clip. This describes
+  /// where the *audio* came from instead: a clip holds one analysis window,
+  /// re-cut as the detection climbs to its confidence peak, so it generally
+  /// sits somewhere in the middle of that span rather than at its start.
+  ///
+  /// Always kept in step with [audioClipPath], so it describes the file
+  /// currently on disk. Only meaningful while [audioClipPath] is non-null.
+  ///
+  /// `null` for sessions recorded before clips followed the peak, where the
+  /// clip was cut on arrival and [timestamp] is the correct fallback.
+  DateTime? clipTimestamp;
 
   /// How this detection was created.
   final DetectionSource source;
@@ -452,6 +469,7 @@ class DetectionRecord {
   factory DetectionRecord.fromDetection(
     Detection detection, {
     String? audioClipPath,
+    DateTime? clipTimestamp,
   }) {
     return DetectionRecord(
       scientificName: detection.species.scientificName,
@@ -459,11 +477,13 @@ class DetectionRecord {
       confidence: detection.confidence,
       timestamp: detection.timestamp ?? DateTime.now(),
       audioClipPath: audioClipPath,
+      clipTimestamp: audioClipPath == null ? null : clipTimestamp,
     );
   }
 
   /// Deserialize from JSON.
   factory DetectionRecord.fromJson(Map<String, dynamic> json) {
+    final audioClipPath = json['audioClipPath'] as String?;
     return DetectionRecord(
       scientificName: json['scientificName'] as String,
       commonName: json['commonName'] as String,
@@ -473,7 +493,11 @@ class DetectionRecord {
           json['endTimestamp'] != null
               ? DateTime.parse(json['endTimestamp'] as String)
               : null,
-      audioClipPath: json['audioClipPath'] as String?,
+      audioClipPath: audioClipPath,
+      clipTimestamp:
+          audioClipPath != null && json['clipTimestamp'] != null
+              ? DateTime.parse(json['clipTimestamp'] as String)
+              : null,
       source: switch (json['source'] as String?) {
         'manual' => DetectionSource.manual,
         'manualGlobal' => DetectionSource.manualGlobal,
@@ -500,6 +524,8 @@ class DetectionRecord {
     if (endTimestamp != null)
       'endTimestamp': endTimestamp!.toUtc().toIso8601String(),
     if (audioClipPath != null) 'audioClipPath': audioClipPath,
+    if (audioClipPath != null && clipTimestamp != null)
+      'clipTimestamp': clipTimestamp!.toUtc().toIso8601String(),
     if (source != DetectionSource.auto) 'source': source.name,
     if (latitude != null) 'detLat': latitude,
     if (longitude != null) 'detLon': longitude,
@@ -1047,6 +1073,16 @@ class LiveSession {
   /// emitted slightly before the recorder fully spun up cannot produce
   /// negative session-relative offsets (e.g. "00:-1") downstream.
   DetectionRecord _clampToSession(DetectionRecord r) {
+    // The clip's own window can start before the session when a detection
+    // lands in the pre-roll; clamp it on the same rule so it can never
+    // produce a negative offset downstream. Done in place — [clipTimestamp]
+    // is mutable, and letting it trigger the copy below would hand back a
+    // different instance than the detection sampler is holding, so a later
+    // eviction would clear the clip on an orphan and leave the session's
+    // record pointing at a deleted file.
+    if (r.clipTimestamp != null && r.clipTimestamp!.isBefore(startTime)) {
+      r.clipTimestamp = startTime;
+    }
     final needsTs = r.timestamp.isBefore(startTime);
     final needsEnd =
         r.endTimestamp != null && r.endTimestamp!.isBefore(startTime);
@@ -1060,6 +1096,7 @@ class LiveSession {
       timestamp: clampedTs,
       endTimestamp: clampedEnd,
       audioClipPath: r.audioClipPath,
+      clipTimestamp: r.clipTimestamp,
       source: r.source,
       latitude: r.latitude,
       longitude: r.longitude,

--- a/lib/features/recording/recording_service.dart
+++ b/lib/features/recording/recording_service.dart
@@ -18,15 +18,32 @@
 //
 // ```
 // <appDir>/recordings/<sessionId>/
-//   full.wav              ← continuous recording (if mode = full)
-//   clip_<timestamp>.wav  ← detection clips (if mode = detectionsOnly)
+//   full.wav                        ← continuous recording (if mode = full)
+//   clip_<timestamp>_<species>.wav  ← detection clips (if detectionsOnly)
 // ```
+//
+// ### Peak-window clips
+//
+// A merged detection spans every consecutive inference window in which the
+// species stayed above threshold — often far more than the single analyzed
+// window a clip holds. Rather than keep the *first* window (which is usually
+// the weakest, since birds enter near the confidence floor and peak later),
+// callers re-cut the clip whenever the detection reaches a new confidence
+// peak: see [DetectionClipPeakTracker] and [kClipPeakImprovementDelta]. The
+// replacement is published before [RecordingService.deleteClip] removes the
+// old file. The clip a session ends up with
+// therefore comes from the strongest window of the detection, matching the
+// confidence stored on the record.
+//
+// Clip file names embed the species so each record owns exactly one file —
+// re-cutting or evicting one detection's clip can never delete audio another
+// record still points at.
 // =============================================================================
 
 import 'dart:async';
 import 'dart:io';
-import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../audio/ring_buffer.dart';
@@ -44,6 +61,129 @@ enum RecordingMode {
 
   /// Save clips around detected species only.
   detectionsOnly,
+}
+
+/// Minimum confidence gain required before a detection's clip is re-cut at a
+/// stronger analysis window.
+///
+/// A merged detection's confidence is the running maximum over its windows,
+/// so without a margin every marginal uptick near the peak would rewrite the
+/// clip file. At 0.05 a re-cut only happens for a meaningfully better window,
+/// which in practice means a handful of writes per detection at most.
+const double kClipPeakImprovementDelta = 0.05;
+
+/// Tracks the confidence represented by each detection's clip on disk, and
+/// decides when a detection wants a clip cut.
+///
+/// This is the single peak-retention rule for the whole app: Live, Survey and
+/// ARU each own an instance and ask it the same question every round, so the
+/// same bird produces the same clip whichever mode heard it. Only the
+/// *subsampling* that runs afterwards — which clips survive to the end of a
+/// session — is deliberately per-mode.
+///
+/// A detection record's confidence is updated for every stronger inference
+/// window, including improvements too small to justify an immediate re-cut.
+/// Comparing a future score to the record would therefore lose cumulative
+/// gains (for example 0.50 -> 0.53 -> 0.56). This tracker keeps the clip's
+/// actual baseline separate from the record's running maximum.
+class DetectionClipPeakTracker {
+  DetectionClipPeakTracker({this.improvementDelta = kClipPeakImprovementDelta})
+    : assert(improvementDelta >= 0);
+
+  final double improvementDelta;
+  final Map<String, double> _savedConfidenceByKey = {};
+
+  /// Whether a clip should be cut for [key] from the audio available now.
+  ///
+  /// A detection that has no clip yet gets one — on arrival ([isNew]), or on
+  /// any later improvement if the earlier attempt produced no file. A
+  /// detection that already has a clip only replaces it once it beats the
+  /// confidence that clip actually represents by [improvementDelta].
+  ///
+  /// [currentConfidence] is the detection record's running maximum. Requiring
+  /// a genuinely newer peak prevents a failed save from retrying every round
+  /// while the score is unchanged.
+  bool needsClip({
+    required String key,
+    required double candidateConfidence,
+    required double currentConfidence,
+    required bool hasClip,
+    required bool isNew,
+  }) {
+    if (!candidateConfidence.isFinite) return false;
+    if (!hasClip) return isNew || candidateConfidence > currentConfidence;
+    // An arriving detection that already carries a clip keeps it; re-cutting
+    // is for detections we have watched improve.
+    if (isNew || candidateConfidence <= currentConfidence) return false;
+
+    final savedConfidence = _savedConfidenceByKey[key] ?? currentConfidence;
+    // Absorb binary floating-point noise at exact boundaries such as
+    // 0.60 - 0.55, which is slightly less than 0.05 on some runtimes.
+    const epsilon = 1e-12;
+    return candidateConfidence - savedConfidence + epsilon >= improvementDelta;
+  }
+
+  /// Record a successful clip save at [confidence].
+  void recordSaved(String key, double confidence) {
+    if (confidence.isFinite) _savedConfidenceByKey[key] = confidence;
+  }
+
+  /// Stop tracking a closed detection.
+  void forget(String key) => _savedConfidenceByKey.remove(key);
+
+  /// Reset all state at a session boundary.
+  void clear() => _savedConfidenceByKey.clear();
+}
+
+/// Builds a unique clip file name for a detection of [scientificName].
+///
+/// The species is slugged into the name so every record owns its own file:
+/// two species detected in the same inference cycle get distinct clips, and
+/// re-cutting one detection's clip never touches another's. [savedAt] and
+/// [sequence] keep successive re-cuts of the same species distinct so the new
+/// file is written before the old one is deleted.
+String detectionClipName(
+  String scientificName,
+  DateTime savedAt, {
+  int sequence = 0,
+}) {
+  final slug = scientificName.replaceAll(RegExp(r'[^A-Za-z0-9_-]+'), '_');
+  return 'clip_${savedAt.microsecondsSinceEpoch}_${sequence}_$slug';
+}
+
+/// Cut one detection clip per entry in [items], all from the same audio.
+///
+/// Live, Survey and ARU all reach the same point in a round: several
+/// detections want a clip of the window that just played. Cutting them
+/// together costs one post-roll wait for the round instead of one per
+/// detection, and — more importantly for consistency — anchors every clip in
+/// the round to the same moment. Cutting them one at a time makes each clip
+/// after the first read the ring buffer later than the window that earned the
+/// score, so the same bird would land on a different window depending on how
+/// many other species happened to peak alongside it.
+///
+/// [speciesOf] supplies the scientific name that goes into each file name.
+/// Returns the written path per item; items whose clip could not be written
+/// are absent from the map.
+Future<Map<T, String>> saveDetectionClipsFor<T>({
+  required RecordingService recordingService,
+  required List<T> items,
+  required String Function(T item) speciesOf,
+}) async {
+  if (items.isEmpty) return const {};
+
+  final namesByItem = {
+    for (final item in items)
+      item: recordingService.nextDetectionClipName(speciesOf(item)),
+  };
+  final written = await recordingService.saveDetectionClips(
+    clipNames: namesByItem.values.toList(),
+  );
+
+  return {
+    for (final entry in namesByItem.entries)
+      if (written[entry.value] != null) entry.key: written[entry.value]!,
+  };
 }
 
 /// Parses a [RecordingMode] from its string name.
@@ -99,6 +239,8 @@ class RecordingService {
   bool _isRecording = false;
   bool _flushing = false;
   int _lastFlushPosition = 0;
+  int _nextClipSequence = 0;
+  int _recordingGeneration = 0;
 
   /// Whether a recording is currently in progress.
   bool get isRecording => _isRecording;
@@ -111,6 +253,19 @@ class RecordingService {
 
   /// Path to the session recording directory.
   String? get sessionDir => _sessionDir;
+
+  /// Return a collision-resistant name for the next detection clip.
+  ///
+  /// The per-service sequence disambiguates saves that share the same system
+  /// clock tick and species name. This matters for replacement safety: a
+  /// re-cut must never overwrite the old file before the new one is complete.
+  String nextDetectionClipName(String scientificName, {DateTime? savedAt}) {
+    return detectionClipName(
+      scientificName,
+      savedAt ?? DateTime.now(),
+      sequence: _nextClipSequence++,
+    );
+  }
 
   /// Start recording for the given session.
   ///
@@ -127,6 +282,7 @@ class RecordingService {
     _mode = mode;
     _format = format;
     _isRecording = true;
+    _recordingGeneration++;
 
     final appDir = await getApplicationDocumentsDirectory();
     _sessionDir = '${appDir.path}/recordings/$sessionId';
@@ -163,38 +319,85 @@ class RecordingService {
   ///
   /// Returns the file path of the saved clip, or `null` if not recording.
   Future<String?> saveDetectionClip({required String clipName}) async {
-    if (!_isRecording || _sessionDir == null) return null;
+    final saved = await saveDetectionClips(clipNames: [clipName]);
+    return saved[clipName];
+  }
+
+  /// Save one clip per entry in [clipNames], all cut from the same audio.
+  ///
+  /// Several species commonly hit a new confidence peak in the same inference
+  /// cycle, and they all want the *same* stretch of audio. Waiting for
+  /// post-roll and reading the ring buffer once — then writing N files from
+  /// that one snapshot — keeps a busy cycle to a single
+  /// [clipContextSeconds] delay instead of one per species.
+  ///
+  /// Returns a map of clip name → written file path. Names whose clip could
+  /// not be written (not recording, or silent audio) are absent from the map.
+  Future<Map<String, String>> saveDetectionClips({
+    required List<String> clipNames,
+  }) async {
+    if (clipNames.isEmpty) return const {};
+    if (!_isRecording || _sessionDir == null) return const {};
+    final generation = _recordingGeneration;
 
     if (clipContextSeconds > 0) {
       await Future<void>.delayed(Duration(seconds: clipContextSeconds));
       // Recording may have been stopped while we were waiting for post-roll.
-      if (!_isRecording || _sessionDir == null) return null;
+      if (!_isRecording ||
+          _sessionDir == null ||
+          generation != _recordingGeneration) {
+        return const {};
+      }
     }
 
+    final sessionDir = _sessionDir!;
+    final format = _format;
     final totalSeconds = windowSeconds + 2 * clipContextSeconds;
     final totalSamples = totalSeconds * sampleRate;
     final samples = ringBuffer.readLast(totalSamples);
 
     // Skip silent clips (all zeros = no audio captured yet).
-    if (_isAllSilent(samples)) return null;
+    if (_isAllSilent(samples)) return const {};
 
-    final ext = _format == 'flac' ? 'flac' : 'wav';
-    final filePath = '$_sessionDir/$clipName.$ext';
-    if (_format == 'flac') {
-      await FlacEncoder.writeFile(
-        filePath: filePath,
-        samples: samples,
-        sampleRate: sampleRate,
-      );
-    } else {
-      await WavWriter.writeFile(
-        filePath: filePath,
-        samples: samples,
-        sampleRate: sampleRate,
-      );
+    final ext = format == 'flac' ? 'flac' : 'wav';
+    final written = <String, String>{};
+    for (final clipName in clipNames.toSet()) {
+      final filePath = '$sessionDir/$clipName.$ext';
+      try {
+        if (format == 'flac') {
+          await FlacEncoder.writeFile(
+            filePath: filePath,
+            samples: samples,
+            sampleRate: sampleRate,
+          );
+        } else {
+          await WavWriter.writeFile(
+            filePath: filePath,
+            samples: samples,
+            sampleRate: sampleRate,
+          );
+        }
+        written[clipName] = filePath;
+      } catch (e, st) {
+        debugPrint(
+          '[RecordingService] failed to save clip "$clipName": $e\n$st',
+        );
+        await deleteClip(filePath);
+      }
     }
 
-    return filePath;
+    return written;
+  }
+
+  /// Delete a detection clip file, swallowing and logging I/O errors.
+  Future<void> deleteClip(String? path) async {
+    if (path == null) return;
+    try {
+      final file = File(path);
+      if (await file.exists()) await file.delete();
+    } catch (e) {
+      debugPrint('[RecordingService] failed to delete clip: $e');
+    }
   }
 
   /// Stop the ongoing recording and finalize any open files.
@@ -205,6 +408,7 @@ class RecordingService {
     if (!_isRecording) return null;
 
     _isRecording = false;
+    _recordingGeneration++;
     _flushTimer?.cancel();
     _flushTimer = null;
 
@@ -252,6 +456,8 @@ class RecordingService {
 
   /// Dispose of all resources.
   void dispose() {
+    _isRecording = false;
+    _recordingGeneration++;
     _flushTimer?.cancel();
     if (_writer?.isOpen == true) {
       _writer!.close();

--- a/lib/features/survey/detection_sampler.dart
+++ b/lib/features/survey/detection_sampler.dart
@@ -53,7 +53,10 @@ SamplingMode samplingModeFromString(String value) {
 /// engines (which use deliberately different *selection* strategies) never
 /// diverge on the actual file teardown. Callers are responsible for clearing
 /// the owning record's `audioClipPath` and updating their own drop counters.
-Future<void> deleteDetectionClipFile(String? path, {required String logTag}) async {
+Future<void> deleteDetectionClipFile(
+  String? path, {
+  required String logTag,
+}) async {
   if (path == null) return;
   try {
     final file = File(path);
@@ -168,6 +171,9 @@ class DetectionSampler {
   Future<void> _evictClip(DetectionRecord record) async {
     final path = record.audioClipPath;
     record.audioClipPath = null;
+    // The window the clip was cut from describes a file that no longer
+    // exists; clearing it keeps the record from advertising audio it lost.
+    record.clipTimestamp = null;
     _droppedClipCount++;
     await deleteDetectionClipFile(path, logTag: 'DetectionSampler');
   }

--- a/lib/features/survey/survey_controller.dart
+++ b/lib/features/survey/survey_controller.dart
@@ -47,6 +47,7 @@ import '../history/session_path_codec.dart';
 import '../inference/advanced_pooling_params.dart';
 import '../inference/inference_isolate.dart';
 import '../inference/model_config.dart';
+import '../inference/models/detection.dart';
 import '../inference/species_filter.dart';
 import '../recording/recording_service.dart';
 import 'detection_sampler.dart';
@@ -121,6 +122,12 @@ class SurveyController {
 
   /// Species currently shown as active detection cards.
   final Map<String, DetectionRecord> _activeCardSpecies = {};
+
+  /// Confidence of the audio window currently saved for each active species.
+  ///
+  /// The detection record itself keeps advancing on every stronger score, even
+  /// when that gain is too small to re-cut immediately.
+  final DetectionClipPeakTracker _clipPeakTracker = DetectionClipPeakTracker();
 
   /// Optional per-survey alert pipeline. `null` when alerts are disabled
   /// for the current survey (mode == off, or no notifier was configured).
@@ -441,6 +448,7 @@ class SurveyController {
       _refreshRecentForNotification();
       _currentLiveDetections = const [];
       _activeCardSpecies.clear();
+      _clipPeakTracker.clear();
       _confidenceThreshold = confidenceThreshold;
       _sensitivity = sensitivity;
       _isolate.setMaxPoolWindows(poolingWindows);
@@ -593,6 +601,7 @@ class SurveyController {
       _refreshRecentForNotification();
       _currentLiveDetections = const [];
       _activeCardSpecies.clear();
+      _clipPeakTracker.clear();
       _confidenceThreshold = confidenceThreshold;
       _sensitivity = sensitivity;
       _isolate.setMaxPoolWindows(poolingWindows);
@@ -717,6 +726,7 @@ class SurveyController {
     _refreshRecentForNotification();
     _currentLiveDetections = const [];
     _activeCardSpecies.clear();
+    _clipPeakTracker.clear();
   }
 
   /// Stop and finalize the survey.
@@ -789,6 +799,7 @@ class SurveyController {
           timestamp: existing.timestamp,
           endTimestamp: now,
           audioClipPath: existing.audioClipPath,
+          clipTimestamp: existing.clipTimestamp,
           source: existing.source,
           latitude: existing.latitude,
           longitude: existing.longitude,
@@ -829,6 +840,7 @@ class SurveyController {
       _refreshRecentForNotification();
       _currentLiveDetections = const [];
       _activeCardSpecies.clear();
+      _clipPeakTracker.clear();
       _gpsTracker = null;
       _sampler = null;
 
@@ -1004,6 +1016,12 @@ class SurveyController {
     try {
       final sampleRate = _config?.audio.sampleRate ?? AppConstants.sampleRate;
       final windowSamples = windowDuration * sampleRate;
+      // Dated at the read so a clip cut from this cycle knows which stretch
+      // of audio it holds. The samples just read end at "now", so the window
+      // they cover starts [windowDuration] earlier.
+      final windowTimestamp = DateTime.now().subtract(
+        Duration(seconds: windowDuration),
+      );
       final audioSamples = ringBuffer.readLast(windowSamples);
 
       if (kDebugMode && _inferenceCycleCount % 30 == 0) {
@@ -1040,7 +1058,8 @@ class SurveyController {
       ];
 
       // Detection counting (card-visibility based, same as LiveController).
-      if (_session != null) {
+      final session = _session;
+      if (session != null) {
         final currentNames = <String>{
           for (final d in filteredDetections) d.species.scientificName,
         };
@@ -1057,6 +1076,7 @@ class SurveyController {
         final closingNow = DateTime.now();
         for (final name in disappeared) {
           final existing = _activeCardSpecies.remove(name);
+          _clipPeakTracker.forget(name);
           if (existing == null) continue;
           // Mutate endTimestamp in place via list-replace (endTimestamp is
           // a final field). The new record carries the same audioClipPath
@@ -1068,6 +1088,7 @@ class SurveyController {
             timestamp: existing.timestamp,
             endTimestamp: closingNow,
             audioClipPath: existing.audioClipPath,
+            clipTimestamp: existing.clipTimestamp,
             source: existing.source,
             latitude: existing.latitude,
             longitude: existing.longitude,
@@ -1087,24 +1108,46 @@ class SurveyController {
         // Get current GPS position for detection tagging.
         final gpsPoint = _gpsTracker?.lastPoint;
 
-        String? clipPath;
-        if (_saveDetectionClips && appeared.isNotEmpty) {
-          final clipName = 'clip_${DateTime.now().millisecondsSinceEpoch}';
-          clipPath = await recordingService.saveDetectionClip(
-            clipName: clipName,
-          );
+        // Cut this cycle's clips: one for each newly appeared species, plus a
+        // re-cut for any ongoing detection that reached a new confidence
+        // peak. A merged detection can span far more windows than a clip
+        // holds, so the window we keep must be the strongest one — the first
+        // window is typically the weakest, since species enter near the
+        // confidence floor and peak a few cycles later. The sampler ranks
+        // clips by peak confidence, so this is also what makes its Top N
+        // choices reflect audio it actually kept.
+        final clipPaths = await _saveCycleClips(
+          filteredDetections,
+          appeared: appeared,
+        );
+
+        // The post-roll wait inside the clip save is the one point in a cycle
+        // where the survey can be torn down underneath us: `stopSurvey` flips
+        // to `stopping` and then closes every active record — handing it to
+        // the sampler — across several awaits of its own. Continuing here
+        // would attach records to a finished survey and, worse, let a re-cut
+        // delete the clip file a just-closed record still points at.
+        if (!identical(_session, session) || _state != SurveyState.active) {
+          for (final path in clipPaths.values) {
+            await recordingService.deleteClip(path);
+          }
+          return;
         }
 
         for (final detection in filteredDetections) {
           final name = detection.species.scientificName;
 
           if (appeared.contains(name)) {
+            // Every clip in this cycle came from one ring-buffer read, so
+            // they all hold the window that just ran: `windowTimestamp`
+            // dates the audio for all of them.
             final record = DetectionRecord(
               scientificName: detection.species.scientificName,
               commonName: detection.species.commonName,
               confidence: detection.confidence,
               timestamp: detection.timestamp ?? DateTime.now(),
-              audioClipPath: clipPath,
+              audioClipPath: clipPaths[name],
+              clipTimestamp: clipPaths[name] == null ? null : windowTimestamp,
               latitude: gpsPoint?.latitude,
               longitude: gpsPoint?.longitude,
             );
@@ -1116,6 +1159,9 @@ class SurveyController {
             _sessionDetections.insert(0, record);
             _refreshRecentForNotification();
             _activeCardSpecies[name] = record;
+            if (record.audioClipPath != null) {
+              _clipPeakTracker.recordSaved(name, detection.confidence);
+            }
             // Feed the alert pipeline AFTER the record is durably tracked
             // so a notification firing implies the detection was kept.
             _alertCoordinator?.onDetection(record);
@@ -1124,12 +1170,22 @@ class SurveyController {
             // appears at the top of the recent detections list.
             final existing = _activeCardSpecies[name]!;
             if (detection.confidence > existing.confidence) {
+              final freshClip = clipPaths[name];
+              final clipPath = freshClip ?? existing.audioClipPath;
               final updated = DetectionRecord(
                 scientificName: existing.scientificName,
                 commonName: existing.commonName,
                 confidence: detection.confidence,
                 timestamp: existing.timestamp,
-                audioClipPath: existing.audioClipPath ?? clipPath,
+                audioClipPath: clipPath,
+                // A re-cut moves the audio to this cycle's window; keeping
+                // the old clip keeps the window it was cut from.
+                clipTimestamp:
+                    clipPath == null
+                        ? null
+                        : (freshClip == null
+                            ? existing.clipTimestamp
+                            : windowTimestamp),
                 source: existing.source,
                 latitude: existing.latitude ?? gpsPoint?.latitude,
                 longitude: existing.longitude ?? gpsPoint?.longitude,
@@ -1140,6 +1196,14 @@ class SurveyController {
               if (lsIdx != -1) _session!.detections[lsIdx] = updated;
               _refreshRecentForNotification();
               _activeCardSpecies[name] = updated;
+
+              if (freshClip != null) {
+                // Publish the replacement before the first await. Otherwise
+                // stopSurvey can persist the old path after its file has
+                // already been deleted.
+                _clipPeakTracker.recordSaved(name, detection.confidence);
+                await recordingService.deleteClip(existing.audioClipPath);
+              }
             }
           }
         }
@@ -1186,6 +1250,42 @@ class SurveyController {
     } finally {
       _inferring = false;
     }
+  }
+
+  /// Cut this cycle's detection clips, returning scientific name → clip path.
+  ///
+  /// Which species need one is [DetectionClipPeakTracker.needsClip]'s call —
+  /// the same rule Live and ARU apply — and they are all cut from a single
+  /// ring-buffer read so the whole cycle costs one post-roll wait.
+  Future<Map<String, String>> _saveCycleClips(
+    List<Detection> detections, {
+    required Set<String> appeared,
+  }) async {
+    if (!_saveDetectionClips) return const {};
+
+    final needsClip = <String>[];
+    for (final detection in detections) {
+      final name = detection.species.scientificName;
+      final isNew = appeared.contains(name);
+      final existing = _activeCardSpecies[name];
+      if (!isNew && existing == null) continue;
+
+      if (_clipPeakTracker.needsClip(
+        key: name,
+        candidateConfidence: detection.confidence,
+        currentConfidence: existing?.confidence ?? detection.confidence,
+        hasClip: existing?.audioClipPath != null,
+        isNew: isNew,
+      )) {
+        needsClip.add(name);
+      }
+    }
+
+    return saveDetectionClipsFor<String>(
+      recordingService: recordingService,
+      items: needsClip,
+      speciesOf: (name) => name,
+    );
   }
 
   // ── Persistence ─────────────────────────────────────────────────────────

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: birdnet_live
 description: "Real-time bird species identification using on-device ONNX inference"
 publish_to: 'none'
-version: 0.19.2+209
+version: 0.19.3+210
 
 environment:
   sdk: ^3.7.0

--- a/test/features/aru/aru_controller_test.dart
+++ b/test/features/aru/aru_controller_test.dart
@@ -4,6 +4,26 @@ import 'package:birdnet_live/features/recording/recording_service.dart';
 import 'package:birdnet_live/features/survey/detection_sampler.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+/// Adapts a per-record clip stub to the batched saver the controller expects.
+///
+/// [cut] returns the path written for a record, or null when nothing was
+/// written. [rounds] records the batch handed to each call, so tests can assert
+/// that a sync round cuts its clips together rather than one at a time.
+AruDetectionClipSaver clipSaver(
+  String? Function(DetectionRecord record) cut, {
+  List<List<DetectionRecord>>? rounds,
+}) {
+  return (session, records) async {
+    rounds?.add(List<DetectionRecord>.of(records));
+    final written = <DetectionRecord, String>{};
+    for (final record in records) {
+      final path = cut(record);
+      if (path != null) written[record] = path;
+    }
+    return written;
+  };
+}
+
 void main() {
   final start = DateTime.utc(2026, 6, 1, 4);
   final settings = SessionSettings(
@@ -413,11 +433,11 @@ void main() {
         final savedClips = <String>[];
         final controller = AruController(
           saveSession: (session) async {},
-          saveDetectionClip: (session, record) async {
+          saveDetectionClips: clipSaver((record) {
             final path = '/recordings/${record.scientificName}.flac';
             savedClips.add(path);
             return path;
-          },
+          }),
           now: () => start.subtract(const Duration(minutes: 5)),
         );
 
@@ -459,15 +479,423 @@ void main() {
       },
     );
 
+    test('syncDetections cuts a round\'s clips in a single batch', () async {
+      // Every clip in a round has to come from one post-roll wait and one
+      // slice of audio, the way the Live and Survey inference loops cut
+      // theirs. Cutting them one at a time made each clip after the first
+      // read the ring buffer later than the window that earned the score, so
+      // the same bird landed on a different window depending on how many
+      // other species happened to peak alongside it.
+      final rounds = <List<DetectionRecord>>[];
+      final controller = AruController(
+        saveSession: (session) async {},
+        saveDetectionClips: clipSaver(
+          (record) => '/recordings/${record.scientificName}.flac',
+          rounds: rounds,
+        ),
+        now: () => start.subtract(const Duration(minutes: 5)),
+      );
+
+      await controller.startDeployment(
+        sessionId: 'aru-1',
+        settings: settings,
+        metadata: metadata(recordingMode: RecordingMode.detectionsOnly.name),
+      );
+      await controller.evaluate(now: start.add(const Duration(minutes: 1)));
+
+      final detectedAt = start.add(const Duration(minutes: 2));
+      DetectionRecord at(String species, double confidence) => DetectionRecord(
+        scientificName: species,
+        commonName: species,
+        confidence: confidence,
+        timestamp: detectedAt,
+      );
+
+      // Three species arriving together: one batch, not three.
+      await controller.syncDetections([
+        at('Turdus merula', 0.55),
+        at('Parus major', 0.60),
+        at('Erithacus rubecula', 0.70),
+      ]);
+
+      expect(rounds, hasLength(1));
+      expect(rounds.single.map((r) => r.scientificName), [
+        'Turdus merula',
+        'Parus major',
+        'Erithacus rubecula',
+      ]);
+
+      // A round mixing a re-cut with a first cut is still one batch, and a
+      // species that has not moved enough is left out of it.
+      await controller.syncDetections([
+        at('Turdus merula', 0.62), // +0.07 over its clip → re-cut
+        at('Parus major', 0.61), // +0.01 → not yet
+        at('Erithacus rubecula', 0.70), // unchanged → no
+        at('Sylvia atricapilla', 0.40), // new → first cut
+      ]);
+
+      expect(rounds, hasLength(2));
+      expect(rounds.last.map((r) => r.scientificName), [
+        'Turdus merula',
+        'Sylvia atricapilla',
+      ]);
+    });
+
+    test('syncDetections cuts no clips when nothing needs one', () async {
+      // An unchanged round must not reach the saver at all — no post-roll
+      // wait, no ring-buffer read.
+      final rounds = <List<DetectionRecord>>[];
+      final controller = AruController(
+        saveSession: (session) async {},
+        saveDetectionClips: clipSaver(
+          (record) => '/recordings/${record.scientificName}.flac',
+          rounds: rounds,
+        ),
+        now: () => start.subtract(const Duration(minutes: 5)),
+      );
+
+      await controller.startDeployment(
+        sessionId: 'aru-1',
+        settings: settings,
+        metadata: metadata(recordingMode: RecordingMode.detectionsOnly.name),
+      );
+      await controller.evaluate(now: start.add(const Duration(minutes: 1)));
+
+      final detectedAt = start.add(const Duration(minutes: 2));
+      DetectionRecord at(double confidence) => DetectionRecord(
+        scientificName: 'Turdus merula',
+        commonName: 'Eurasian Blackbird',
+        confidence: confidence,
+        timestamp: detectedAt,
+      );
+
+      await controller.syncDetections([at(0.55)]);
+      await controller.syncDetections([at(0.56)]);
+      await controller.syncDetections([at(0.56)]);
+
+      expect(rounds, hasLength(1));
+    });
+
+    test(
+      'syncDetections cuts no clips when the mode is not clip-only',
+      () async {
+        final rounds = <List<DetectionRecord>>[];
+        final controller = AruController(
+          saveSession: (session) async {},
+          saveDetectionClips: clipSaver(
+            (record) => '/recordings/${record.scientificName}.flac',
+            rounds: rounds,
+          ),
+          now: () => start.subtract(const Duration(minutes: 5)),
+        );
+
+        await controller.startDeployment(
+          sessionId: 'aru-1',
+          settings: settings,
+          metadata: metadata(recordingMode: RecordingMode.full.name),
+        );
+        await controller.evaluate(now: start.add(const Duration(minutes: 1)));
+
+        await controller.syncDetections([
+          DetectionRecord(
+            scientificName: 'Turdus merula',
+            commonName: 'Eurasian Blackbird',
+            confidence: 0.9,
+            timestamp: start.add(const Duration(minutes: 2)),
+          ),
+        ]);
+
+        expect(rounds, isEmpty);
+        expect(controller.session!.detections.single.audioClipPath, isNull);
+      },
+    );
+
+    test('syncDetections keeps a clip a record already arrived with', () async {
+      // Nothing to cut: the record was handed to us with audio attached, and
+      // it becomes the baseline later peaks are measured against.
+      final rounds = <List<DetectionRecord>>[];
+      final controller = AruController(
+        saveSession: (session) async {},
+        saveDetectionClips: clipSaver(
+          (record) => '/recordings/recut.flac',
+          rounds: rounds,
+        ),
+        now: () => start.subtract(const Duration(minutes: 5)),
+      );
+
+      await controller.startDeployment(
+        sessionId: 'aru-1',
+        settings: settings,
+        metadata: metadata(recordingMode: RecordingMode.detectionsOnly.name),
+      );
+      await controller.evaluate(now: start.add(const Duration(minutes: 1)));
+
+      final detectedAt = start.add(const Duration(minutes: 2));
+      DetectionRecord at(double confidence, {String? clip}) => DetectionRecord(
+        scientificName: 'Turdus merula',
+        commonName: 'Eurasian Blackbird',
+        confidence: confidence,
+        timestamp: detectedAt,
+        audioClipPath: clip,
+      );
+
+      await controller.syncDetections([at(0.55, clip: '/recordings/pre.flac')]);
+      expect(rounds, isEmpty);
+      expect(
+        controller.session!.detections.single.audioClipPath,
+        '/recordings/pre.flac',
+      );
+
+      // A gain measured from 0.55 — the score of the clip it arrived with.
+      await controller.syncDetections([at(0.57)]);
+      expect(rounds, isEmpty);
+      await controller.syncDetections([at(0.61)]);
+      expect(rounds, hasLength(1));
+      expect(
+        controller.session!.detections.single.audioClipPath,
+        '/recordings/recut.flac',
+      );
+    });
+
+    test('syncDetections dates each clip from the audio it holds', () async {
+      // The detection keeps its own start and end — that is when the bird
+      // was heard. The clip window moves with the audio, so the two drift
+      // apart as the detection climbs to its peak. Conflating them is what
+      // made session review advertise a whole detection's worth of audio
+      // next to a file holding one analysis window.
+      var clock = start.add(const Duration(minutes: 2));
+      final controller = AruController(
+        saveSession: (session) async {},
+        saveDetectionClips: clipSaver(
+          (record) => '/recordings/clip_${clock.minute}.flac',
+        ),
+        now: () => clock,
+      );
+
+      await controller.startDeployment(
+        sessionId: 'aru-1',
+        settings: settings,
+        metadata: metadata(recordingMode: RecordingMode.detectionsOnly.name),
+      );
+      await controller.evaluate(now: start.add(const Duration(minutes: 1)));
+
+      final detectedAt = start.add(const Duration(minutes: 2));
+      DetectionRecord at(double confidence) => DetectionRecord(
+        scientificName: 'Turdus merula',
+        commonName: 'Eurasian Blackbird',
+        confidence: confidence,
+        timestamp: detectedAt,
+      );
+
+      // First cut: the clip holds the window ending now.
+      await controller.syncDetections([at(0.55)]);
+      final firstWindow = clock.subtract(
+        Duration(seconds: settings.windowDuration),
+      );
+      expect(controller.session!.detections.single.clipTimestamp, firstWindow);
+
+      // Three minutes later the detection peaks and the clip is re-cut. The
+      // detection still starts where it always did; the clip does not.
+      clock = start.add(const Duration(minutes: 5));
+      await controller.syncDetections([at(0.61)]);
+
+      final synced = controller.session!.detections.single;
+      expect(synced.timestamp, detectedAt);
+      expect(
+        synced.clipTimestamp,
+        clock.subtract(Duration(seconds: settings.windowDuration)),
+      );
+      expect(synced.clipTimestamp!.isAfter(synced.timestamp), isTrue);
+    });
+
+    test('clip timing is captured before the post-roll wait', () async {
+      var clock = start.add(const Duration(minutes: 2));
+      final cutAt = clock;
+      final controller = AruController(
+        saveSession: (session) async {},
+        saveDetectionClips: (session, records) async {
+          // Stand in for RecordingService waiting for clip context.
+          clock = clock.add(const Duration(seconds: 2));
+          return {records.single: '/recordings/clip.flac'};
+        },
+        now: () => clock,
+      );
+
+      await controller.startDeployment(
+        sessionId: 'aru-1',
+        settings: settings,
+        metadata: metadata(recordingMode: RecordingMode.detectionsOnly.name),
+      );
+      await controller.evaluate(now: start.add(const Duration(minutes: 1)));
+      await controller.syncDetections([
+        DetectionRecord(
+          scientificName: 'Turdus merula',
+          commonName: 'Eurasian Blackbird',
+          confidence: 0.55,
+          timestamp: cutAt,
+        ),
+      ]);
+
+      expect(
+        controller.session!.detections.single.clipTimestamp,
+        cutAt.subtract(Duration(seconds: settings.windowDuration)),
+      );
+    });
+
+    test(
+      'syncDetections leaves the clip window alone without a re-cut',
+      () async {
+        // A gain too small to re-cut must not move the window: the file on
+        // disk is still the old one.
+        var clock = start.add(const Duration(minutes: 2));
+        final controller = AruController(
+          saveSession: (session) async {},
+          saveDetectionClips: clipSaver((record) => '/recordings/clip.flac'),
+          now: () => clock,
+        );
+
+        await controller.startDeployment(
+          sessionId: 'aru-1',
+          settings: settings,
+          metadata: metadata(recordingMode: RecordingMode.detectionsOnly.name),
+        );
+        await controller.evaluate(now: start.add(const Duration(minutes: 1)));
+
+        DetectionRecord at(double confidence) => DetectionRecord(
+          scientificName: 'Turdus merula',
+          commonName: 'Eurasian Blackbird',
+          confidence: confidence,
+          timestamp: start.add(const Duration(minutes: 2)),
+        );
+
+        await controller.syncDetections([at(0.55)]);
+        final firstWindow = controller.session!.detections.single.clipTimestamp;
+        expect(firstWindow, isNotNull);
+
+        clock = start.add(const Duration(minutes: 5));
+        await controller.syncDetections([at(0.57)]);
+
+        expect(
+          controller.session!.detections.single.clipTimestamp,
+          firstWindow,
+        );
+      },
+    );
+
+    test(
+      'syncDetections re-cuts an open detection clip at its confidence peak',
+      () async {
+        // A merged detection spans many analysis windows but its clip holds
+        // one, so the clip must follow the peak rather than stay on the first
+        // (usually weakest) window the species appeared in.
+        final savedClips = <String>[];
+        final controller = AruController(
+          saveSession: (session) async {},
+          saveDetectionClips: clipSaver((record) {
+            final path = '/recordings/clip_${savedClips.length}.flac';
+            savedClips.add(path);
+            return path;
+          }),
+          now: () => start.subtract(const Duration(minutes: 5)),
+        );
+
+        await controller.startDeployment(
+          sessionId: 'aru-1',
+          settings: settings,
+          metadata: metadata(recordingMode: RecordingMode.detectionsOnly.name),
+        );
+        await controller.evaluate(now: start.add(const Duration(minutes: 1)));
+
+        final detectedAt = start.add(const Duration(minutes: 2));
+        DetectionRecord at(double confidence) => DetectionRecord(
+          scientificName: 'Turdus merula',
+          commonName: 'Eurasian Blackbird',
+          confidence: confidence,
+          timestamp: detectedAt,
+        );
+
+        await controller.syncDetections([at(0.55)]);
+        // Each individual gain is below the improvement margin, so the clip
+        // must not churn before their cumulative gain reaches the threshold.
+        await controller.syncDetections([at(0.57)]);
+        await controller.syncDetections([at(0.59)]);
+        expect(savedClips, ['/recordings/clip_0.flac']);
+        expect(
+          controller.session!.detections.single.audioClipPath,
+          '/recordings/clip_0.flac',
+        );
+
+        // 0.61 is only two points above the latest record, but six points
+        // above the 0.55 window represented by the saved clip: re-cut here.
+        await controller.syncDetections([at(0.61)]);
+
+        expect(savedClips, [
+          '/recordings/clip_0.flac',
+          '/recordings/clip_1.flac',
+        ]);
+        final synced = controller.session!.detections.single;
+        expect(synced.audioClipPath, '/recordings/clip_1.flac');
+        expect(synced.confidence, 0.61);
+      },
+    );
+
+    test(
+      'syncDetections does not re-cut a clip once the detection has closed',
+      () async {
+        // After the species stops vocalizing the ring buffer holds later,
+        // unrelated audio — the same reason the first clip is cut on arrival.
+        final savedClips = <String>[];
+        final controller = AruController(
+          saveSession: (session) async {},
+          saveDetectionClips: clipSaver((record) {
+            final path = '/recordings/clip_${savedClips.length}.flac';
+            savedClips.add(path);
+            return path;
+          }),
+          now: () => start.subtract(const Duration(minutes: 5)),
+        );
+
+        await controller.startDeployment(
+          sessionId: 'aru-1',
+          settings: settings,
+          metadata: metadata(recordingMode: RecordingMode.detectionsOnly.name),
+        );
+        await controller.evaluate(now: start.add(const Duration(minutes: 1)));
+
+        final detectedAt = start.add(const Duration(minutes: 2));
+        final endedAt = detectedAt.add(const Duration(seconds: 20));
+        DetectionRecord at(double confidence, {DateTime? end}) =>
+            DetectionRecord(
+              scientificName: 'Turdus merula',
+              commonName: 'Eurasian Blackbird',
+              confidence: confidence,
+              timestamp: detectedAt,
+              endTimestamp: end,
+            );
+
+        await controller.syncDetections([at(0.5)]);
+        // Closing sync carries the final peak; still no re-cut.
+        await controller.syncDetections([at(0.95, end: endedAt)]);
+        // A late re-sync of the already-closed record must not re-cut either.
+        await controller.syncDetections([at(0.99, end: endedAt)]);
+
+        expect(savedClips, ['/recordings/clip_0.flac']);
+        expect(
+          controller.session!.detections.single.audioClipPath,
+          '/recordings/clip_0.flac',
+        );
+      },
+    );
+
     test(
       'syncDetections keeps saved clip paths attached to their timestamps',
       () async {
         final controller = AruController(
           saveSession: (session) async {},
-          saveDetectionClip: (session, record) async {
+          saveDetectionClips: clipSaver((record) {
             final timestamp = record.timestamp.toUtc().millisecondsSinceEpoch;
             return '/recordings/clip_$timestamp.flac';
-          },
+          }),
           now: () => start.subtract(const Duration(minutes: 5)),
         );
 
@@ -542,11 +970,11 @@ void main() {
       () async {
         final controller = AruController(
           saveSession: (session) async {},
-          saveDetectionClip: (session, record) async {
+          saveDetectionClips: clipSaver((record) {
             final timestamp = record.timestamp.toUtc().millisecondsSinceEpoch;
             final species = record.scientificName.replaceAll(' ', '_');
             return '/recordings/clip_${timestamp}_$species.flac';
-          },
+          }),
           now: () => start.subtract(const Duration(minutes: 5)),
         );
 
@@ -636,76 +1064,73 @@ void main() {
       },
     );
 
-    test(
-      'saves a separate session per cycle and keeps no aggregate when '
-      'eachCycleIsSession is true',
-      () async {
-        final store = <String, LiveSession>{};
-        final controller = AruController(
-          saveSession: (session) async => store[session.id] = session,
-          discardSession: (sessionId) async => store.remove(sessionId),
-          now: () => start.subtract(const Duration(minutes: 5)),
-        );
+    test('saves a separate session per cycle and keeps no aggregate when '
+        'eachCycleIsSession is true', () async {
+      final store = <String, LiveSession>{};
+      final controller = AruController(
+        saveSession: (session) async => store[session.id] = session,
+        discardSession: (sessionId) async => store.remove(sessionId),
+        now: () => start.subtract(const Duration(minutes: 5)),
+      );
 
-        await controller.startDeployment(
-          sessionId: 'aru-1',
-          settings: settings,
-          metadata: AruDeploymentMetadata(
-            deploymentName: 'eBird plot',
-            scheduleStart: start,
-            cycleDurationSeconds: 600,
-            repeatIntervalSeconds: 3600,
-            maxCycles: 3,
-            eachCycleIsSession: true,
-          ),
-          sessionNumber: 12,
-        );
+      await controller.startDeployment(
+        sessionId: 'aru-1',
+        settings: settings,
+        metadata: AruDeploymentMetadata(
+          deploymentName: 'eBird plot',
+          scheduleStart: start,
+          cycleDurationSeconds: 600,
+          repeatIntervalSeconds: 3600,
+          maxCycles: 3,
+          eachCycleIsSession: true,
+        ),
+        sessionNumber: 12,
+      );
 
-        // Enter and leave cycles 0, 1, and 2.
-        await controller.evaluate(now: start.add(const Duration(minutes: 5)));
-        await controller.evaluate(now: start.add(const Duration(minutes: 30)));
-        await controller.evaluate(
-          now: start.add(const Duration(hours: 1, minutes: 5)),
-        );
-        await controller.evaluate(
-          now: start.add(const Duration(hours: 1, minutes: 30)),
-        );
-        await controller.evaluate(
-          now: start.add(const Duration(hours: 2, minutes: 5)),
-        );
-        await controller.evaluate(
-          now: start.add(const Duration(hours: 2, minutes: 30)),
-        );
+      // Enter and leave cycles 0, 1, and 2.
+      await controller.evaluate(now: start.add(const Duration(minutes: 5)));
+      await controller.evaluate(now: start.add(const Duration(minutes: 30)));
+      await controller.evaluate(
+        now: start.add(const Duration(hours: 1, minutes: 5)),
+      );
+      await controller.evaluate(
+        now: start.add(const Duration(hours: 1, minutes: 30)),
+      );
+      await controller.evaluate(
+        now: start.add(const Duration(hours: 2, minutes: 5)),
+      );
+      await controller.evaluate(
+        now: start.add(const Duration(hours: 2, minutes: 30)),
+      );
 
-        // Only the per-cycle sessions remain; the aggregate (full-audio mode
-        // included) is discarded so it never lingers in the library.
-        final cycleSessions =
-            store.values.where((s) => s.id.contains('_cycle_')).toList();
-        final aggregateSessions =
-            store.values.where((s) => !s.id.contains('_cycle_')).toList();
-        expect(aggregateSessions, isEmpty);
-        expect(cycleSessions, hasLength(3));
-        expect(cycleSessions.first.id, 'aru-1_cycle_0');
-        expect(cycleSessions.first.sessionNumber, 12);
-        expect(cycleSessions.first.customName, 'eBird plot - Cycle 1');
-        expect(cycleSessions.last.id, 'aru-1_cycle_2');
-        expect(cycleSessions.last.sessionNumber, 12);
-        expect(cycleSessions.last.customName, 'eBird plot - Cycle 3');
-        expect(cycleSessions.first.startTime, start);
-        expect(
-          cycleSessions.first.endTime,
-          start.add(const Duration(minutes: 10)),
-        );
-        expect(cycleSessions.first.aruMetadata, isNotNull);
-        expect(cycleSessions.first.aruMetadata!.cycles.single.index, 0);
-        expect(
-          cycleSessions.first.aruMetadata!.cycles.single.status,
-          AruCycleStatus.completed,
-        );
-        expect(cycleSessions.first.aruMetadata!.eachCycleIsSession, isTrue);
-        expect(controller.reviewSession, cycleSessions.last);
-      },
-    );
+      // Only the per-cycle sessions remain; the aggregate (full-audio mode
+      // included) is discarded so it never lingers in the library.
+      final cycleSessions =
+          store.values.where((s) => s.id.contains('_cycle_')).toList();
+      final aggregateSessions =
+          store.values.where((s) => !s.id.contains('_cycle_')).toList();
+      expect(aggregateSessions, isEmpty);
+      expect(cycleSessions, hasLength(3));
+      expect(cycleSessions.first.id, 'aru-1_cycle_0');
+      expect(cycleSessions.first.sessionNumber, 12);
+      expect(cycleSessions.first.customName, 'eBird plot - Cycle 1');
+      expect(cycleSessions.last.id, 'aru-1_cycle_2');
+      expect(cycleSessions.last.sessionNumber, 12);
+      expect(cycleSessions.last.customName, 'eBird plot - Cycle 3');
+      expect(cycleSessions.first.startTime, start);
+      expect(
+        cycleSessions.first.endTime,
+        start.add(const Duration(minutes: 10)),
+      );
+      expect(cycleSessions.first.aruMetadata, isNotNull);
+      expect(cycleSessions.first.aruMetadata!.cycles.single.index, 0);
+      expect(
+        cycleSessions.first.aruMetadata!.cycles.single.status,
+        AruCycleStatus.completed,
+      );
+      expect(cycleSessions.first.aruMetadata!.eachCycleIsSession, isTrue);
+      expect(controller.reviewSession, cycleSessions.last);
+    });
 
     test(
       'does not persist aggregate session for clip-only per-cycle deployment',
@@ -790,9 +1215,7 @@ void main() {
 
         // Stop while still in the initial waiting window (the first cycle has
         // not started, so no per-cycle session exists yet).
-        await controller.stop(
-          now: start.subtract(const Duration(minutes: 1)),
-        );
+        await controller.stop(now: start.subtract(const Duration(minutes: 1)));
 
         final cycleSessions =
             saved.where((s) => s.id.contains('_cycle_')).toList();
@@ -918,9 +1341,7 @@ void main() {
           recordingSuppressed: true,
         );
         // Battery recovers later in the same window: must not re-enter it.
-        await controller.evaluate(
-          now: start.add(const Duration(minutes: 5)),
-        );
+        await controller.evaluate(now: start.add(const Duration(minutes: 5)));
 
         final cycle = controller.session!.aruMetadata!.cycles.single;
         expect(controller.state, AruControllerState.waiting);
@@ -929,58 +1350,64 @@ void main() {
       },
     );
 
-    test('records the next cycle once recording is no longer suppressed', () async {
-      final controller = AruController(
-        saveSession: (session) async {},
-        now: () => start.subtract(const Duration(minutes: 5)),
-      );
+    test(
+      'records the next cycle once recording is no longer suppressed',
+      () async {
+        final controller = AruController(
+          saveSession: (session) async {},
+          now: () => start.subtract(const Duration(minutes: 5)),
+        );
 
-      await controller.startDeployment(
-        sessionId: 'aru-1',
-        settings: settings,
-        metadata: metadata(),
-      );
-      // Cycle 0 skipped for low battery.
-      await controller.evaluate(
-        now: start.add(const Duration(minutes: 5)),
-        recordingSuppressed: true,
-      );
-      // Cycle 1 records normally after recovery.
-      await controller.evaluate(
-        now: start.add(const Duration(hours: 1, minutes: 1)),
-      );
+        await controller.startDeployment(
+          sessionId: 'aru-1',
+          settings: settings,
+          metadata: metadata(),
+        );
+        // Cycle 0 skipped for low battery.
+        await controller.evaluate(
+          now: start.add(const Duration(minutes: 5)),
+          recordingSuppressed: true,
+        );
+        // Cycle 1 records normally after recovery.
+        await controller.evaluate(
+          now: start.add(const Duration(hours: 1, minutes: 1)),
+        );
 
-      final cycles = controller.session!.aruMetadata!.cycles;
-      expect(cycles.map((c) => c.index), <int>[0, 1]);
-      expect(cycles.first.status, AruCycleStatus.skipped);
-      expect(cycles.last.status, AruCycleStatus.recording);
-      expect(controller.state, AruControllerState.recording);
-      expect(controller.session!.segments, hasLength(1));
-    });
+        final cycles = controller.session!.aruMetadata!.cycles;
+        expect(cycles.map((c) => c.index), <int>[0, 1]);
+        expect(cycles.first.status, AruCycleStatus.skipped);
+        expect(cycles.last.status, AruCycleStatus.recording);
+        expect(controller.state, AruControllerState.recording);
+        expect(controller.session!.segments, hasLength(1));
+      },
+    );
 
-    test('marks an in-progress cycle partial when battery drops mid-cycle', () async {
-      final controller = AruController(
-        saveSession: (session) async {},
-        now: () => start.subtract(const Duration(minutes: 5)),
-      );
+    test(
+      'marks an in-progress cycle partial when battery drops mid-cycle',
+      () async {
+        final controller = AruController(
+          saveSession: (session) async {},
+          now: () => start.subtract(const Duration(minutes: 5)),
+        );
 
-      await controller.startDeployment(
-        sessionId: 'aru-1',
-        settings: settings,
-        metadata: metadata(),
-      );
-      // Cycle 0 starts recording normally.
-      await controller.evaluate(now: start.add(const Duration(minutes: 2)));
-      // Battery drops mid-cycle: suppress recording.
-      await controller.evaluate(
-        now: start.add(const Duration(minutes: 5)),
-        recordingSuppressed: true,
-      );
+        await controller.startDeployment(
+          sessionId: 'aru-1',
+          settings: settings,
+          metadata: metadata(),
+        );
+        // Cycle 0 starts recording normally.
+        await controller.evaluate(now: start.add(const Duration(minutes: 2)));
+        // Battery drops mid-cycle: suppress recording.
+        await controller.evaluate(
+          now: start.add(const Duration(minutes: 5)),
+          recordingSuppressed: true,
+        );
 
-      final cycle = controller.session!.aruMetadata!.cycles.single;
-      expect(controller.state, AruControllerState.waiting);
-      expect(cycle.status, AruCycleStatus.partial);
-      expect(cycle.actualEnd, start.add(const Duration(minutes: 5)));
-    });
+        final cycle = controller.session!.aruMetadata!.cycles.single;
+        expect(controller.state, AruControllerState.waiting);
+        expect(cycle.status, AruCycleStatus.partial);
+        expect(cycle.actualEnd, start.add(const Duration(minutes: 5)));
+      },
+    );
   });
 }

--- a/test/features/history/detection_audio_window_test.dart
+++ b/test/features/history/detection_audio_window_test.dart
@@ -1,0 +1,166 @@
+// =============================================================================
+// Detection Audio Window Tests
+// =============================================================================
+//
+// Covers the split between the two things a detection knows about time:
+// when the *bird* was heard (timestamp .. endTimestamp) and where the *clip*
+// on disk came from (clipTimestamp). Exports place the detection inside the
+// clip using the latter, so getting it wrong silently mis-labels every
+// Raven/CSV row of a detection-clip session.
+// =============================================================================
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:birdnet_live/features/history/services/detection_audio_window.dart';
+import 'package:birdnet_live/features/live/live_session.dart';
+
+void main() {
+  final sessionStart = DateTime.utc(2026, 2, 28, 14, 0, 0);
+
+  LiveSession sessionWith(List<DetectionRecord> detections) {
+    return LiveSession(
+      id: 'window-test',
+      startTime: sessionStart,
+      detections: detections,
+      settings: SessionSettings(
+        windowDuration: 3,
+        confidenceThreshold: 25,
+        inferenceRate: 1.0,
+        speciesFilterMode: 'off',
+      ),
+    );
+  }
+
+  DetectionRecord record({
+    Duration start = const Duration(minutes: 1),
+    Duration? end,
+    String? clipPath,
+    Duration? clipWindow,
+  }) {
+    return DetectionRecord(
+      scientificName: 'Turdus merula',
+      commonName: 'Eurasian Blackbird',
+      confidence: 0.8,
+      timestamp: sessionStart.add(start),
+      endTimestamp: end == null ? null : sessionStart.add(end),
+      audioClipPath: clipPath,
+      clipTimestamp: clipWindow == null ? null : sessionStart.add(clipWindow),
+    );
+  }
+
+  group('detectionDurationSeconds', () {
+    test('uses the full span the species stayed above threshold', () {
+      final r = record(
+        start: const Duration(minutes: 1),
+        end: const Duration(minutes: 1, seconds: 24),
+      );
+      expect(detectionDurationSeconds(r, sessionWith([r]).settings), 24.0);
+    });
+
+    test('falls back to one analysis window when still open', () {
+      final r = record(start: const Duration(minutes: 1));
+      expect(detectionDurationSeconds(r, sessionWith([r]).settings), 3.0);
+    });
+  });
+
+  group('detectionAudioWindow', () {
+    test('anchors the clip at the window it was cut from', () {
+      // Heard 60 s .. 84 s into the session, but the clip holds the window
+      // at 78 s — where the detection peaked — plus 1 s of padding.
+      final r = record(
+        start: const Duration(minutes: 1),
+        end: const Duration(minutes: 1, seconds: 24),
+        clipPath: '/recordings/clip.wav',
+        clipWindow: const Duration(seconds: 78),
+      );
+      final w = detectionAudioWindow(
+        sessionWith([r]),
+        r,
+        clipContextSeconds: 1,
+      );
+
+      // The detection itself is unchanged: it is still a 24-second event.
+      expect(w.detectionStartSec, 60.0);
+      expect(w.detectionDurationSec, 24.0);
+
+      // The clip is one window plus padding on both sides, at the peak.
+      expect(w.clipStartSec, 77.0);
+      expect(w.clipDurationSec, 5.0);
+      expect(w.clipDetectionStartSec, 1.0);
+      expect(w.clipDetectionEndSec, 4.0);
+    });
+
+    test('a clip never claims the whole detection span', () {
+      // The bug this guards: a 24-second detection whose clip is 5 seconds
+      // long must not report a 26-second clip.
+      final r = record(
+        start: const Duration(minutes: 1),
+        end: const Duration(minutes: 1, seconds: 24),
+        clipPath: '/recordings/clip.wav',
+        clipWindow: const Duration(seconds: 78),
+      );
+      final w = detectionAudioWindow(
+        sessionWith([r]),
+        r,
+        clipContextSeconds: 1,
+      );
+
+      expect(w.clipDurationSec, lessThan(w.detectionDurationSec));
+    });
+
+    test('legacy clips still span exactly one analysis window', () {
+      // Sessions recorded before clips followed the peak cut on arrival, so
+      // the detection start is exactly where their clip begins.
+      final r = record(
+        start: const Duration(minutes: 1),
+        end: const Duration(minutes: 1, seconds: 24),
+        clipPath: '/recordings/clip.wav',
+      );
+      final w = detectionAudioWindow(
+        sessionWith([r]),
+        r,
+        clipContextSeconds: 1,
+      );
+
+      expect(w.clipStartSec, 59.0);
+      expect(w.clipDetectionStartSec, 1.0);
+      expect(w.clipDetectionEndSec, 4.0);
+      expect(w.clipDurationSec, 5.0);
+    });
+
+    test('clamps the clip start at the beginning of the recording', () {
+      // A detection in the first second has less pre-roll than requested.
+      final r = record(
+        start: Duration.zero,
+        clipPath: '/recordings/clip.wav',
+        clipWindow: Duration.zero,
+      );
+      final w = detectionAudioWindow(
+        sessionWith([r]),
+        r,
+        clipContextSeconds: 2,
+      );
+
+      expect(w.clipStartSec, 0.0);
+      expect(w.clipDetectionStartSec, 2.0);
+    });
+
+    test('zero context yields a clip of exactly one window', () {
+      final r = record(
+        start: const Duration(minutes: 1),
+        end: const Duration(minutes: 1, seconds: 24),
+        clipPath: '/recordings/clip.wav',
+        clipWindow: const Duration(seconds: 78),
+      );
+      final w = detectionAudioWindow(
+        sessionWith([r]),
+        r,
+        clipContextSeconds: 0,
+      );
+
+      expect(w.clipStartSec, 78.0);
+      expect(w.clipDurationSec, 3.0);
+      expect(w.clipDetectionStartSec, 0.0);
+    });
+  });
+}

--- a/test/features/history/session_export_test.dart
+++ b/test/features/history/session_export_test.dart
@@ -365,7 +365,7 @@ void main() {
       expect(cols[5], '19.000');
     });
 
-    test('uses endTimestamp for continuous detections inside clips', () {
+    test('clip rows cover one analysis window for continuous detections', () {
       final start = DateTime.utc(2025, 6, 15, 8, 0, 0);
       final session = _makeSession(
         windowDuration: 3,
@@ -389,7 +389,7 @@ void main() {
       final cols = table.split('\n')[1].split('\t');
 
       expect(cols[4], '1.000');
-      expect(cols[5], '15.000');
+      expect(cols[5], '4.000');
       expect(cols[11], '5.000');
     });
 

--- a/test/features/live/live_session_test.dart
+++ b/test/features/live/live_session_test.dart
@@ -137,6 +137,91 @@ void main() {
       expect(record.audioClipPath, isNull);
     });
 
+    test('fromDetection records the window a clip was cut from', () {
+      final windowStart = DateTime(2026, 2, 28, 14, 30, 12);
+      final record = DetectionRecord.fromDetection(
+        testDetection,
+        audioClipPath: '/tmp/clip.wav',
+        clipTimestamp: windowStart,
+      );
+
+      // The bird was first heard at 14:30:00 but the clip holds the window
+      // starting at 14:30:12 — the two are deliberately different.
+      expect(record.timestamp, DateTime(2026, 2, 28, 14, 30, 0));
+      expect(record.clipTimestamp, windowStart);
+    });
+
+    test('fromDetection ignores a clip window with no clip', () {
+      final record = DetectionRecord.fromDetection(
+        testDetection,
+        clipTimestamp: DateTime(2026, 2, 28, 14, 30, 12),
+      );
+
+      expect(record.audioClipPath, isNull);
+      expect(record.clipTimestamp, isNull);
+    });
+
+    test('clipTimestamp survives a JSON round-trip', () {
+      // UTC in, UTC out — toJson normalizes, matching the other timestamps.
+      final record = DetectionRecord(
+        scientificName: 'Turdus merula',
+        commonName: 'Eurasian Blackbird',
+        confidence: 0.85,
+        timestamp: DateTime.utc(2026, 2, 28, 14, 30, 0),
+        endTimestamp: DateTime.utc(2026, 2, 28, 14, 30, 30),
+        audioClipPath: '/recordings/clip.wav',
+        clipTimestamp: DateTime.utc(2026, 2, 28, 14, 30, 12),
+      );
+
+      final restored = DetectionRecord.fromJson(
+        jsonDecode(jsonEncode(record.toJson())) as Map<String, dynamic>,
+      );
+
+      expect(restored.clipTimestamp, record.clipTimestamp);
+      expect(restored.timestamp, record.timestamp);
+      expect(restored.endTimestamp, record.endTimestamp);
+    });
+
+    test('a record with no clip does not persist a clip window', () {
+      // The sampler clears the path when it evicts a clip; the window it was
+      // cut from describes a file that no longer exists.
+      final record = DetectionRecord(
+        scientificName: 'Turdus merula',
+        commonName: 'Eurasian Blackbird',
+        confidence: 0.85,
+        timestamp: DateTime(2026, 2, 28, 14, 30, 0),
+        clipTimestamp: DateTime(2026, 2, 28, 14, 30, 12),
+      );
+
+      expect(record.toJson().containsKey('clipTimestamp'), isFalse);
+    });
+
+    test('legacy records without a clip window round-trip as null', () {
+      final restored = DetectionRecord.fromJson({
+        'scientificName': 'Turdus merula',
+        'commonName': 'Eurasian Blackbird',
+        'confidence': 0.85,
+        'timestamp': DateTime.utc(2026, 2, 28, 14, 30).toIso8601String(),
+        'audioClipPath': '/recordings/clip.wav',
+      });
+
+      expect(restored.clipTimestamp, isNull);
+    });
+
+    test('fromJson ignores a clip window when the clip path is absent', () {
+      final restored = DetectionRecord.fromJson({
+        'scientificName': 'Turdus merula',
+        'commonName': 'Eurasian Blackbird',
+        'confidence': 0.85,
+        'timestamp': DateTime.utc(2026, 2, 28, 14, 30).toIso8601String(),
+        'clipTimestamp':
+            DateTime.utc(2026, 2, 28, 14, 30, 12).toIso8601String(),
+      });
+
+      expect(restored.audioClipPath, isNull);
+      expect(restored.clipTimestamp, isNull);
+    });
+
     test('confidencePercent formats correctly', () {
       final record = DetectionRecord(
         scientificName: 'Turdus merula',

--- a/test/features/recording/recording_service_test.dart
+++ b/test/features/recording/recording_service_test.dart
@@ -2,12 +2,41 @@
 // Recording Service Tests
 // =============================================================================
 
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+// ignore: depend_on_referenced_packages
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+// ignore: depend_on_referenced_packages
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'package:birdnet_live/features/audio/ring_buffer.dart';
 import 'package:birdnet_live/features/recording/recording_service.dart';
+
+class _FakePathProvider extends PathProviderPlatform
+    with MockPlatformInterfaceMixin {
+  _FakePathProvider(this.tmp);
+  final String tmp;
+
+  @override
+  Future<String?> getTemporaryPath() async => tmp;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => tmp;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => tmp;
+}
+
+/// Fills [ringBuffer] with non-silent audio so clips are actually written.
+void _writeTone(RingBuffer ringBuffer, int count) {
+  final data = Float32List(count);
+  for (var i = 0; i < count; i++) {
+    data[i] = ((i % 20) - 10) / 10.0;
+  }
+  ringBuffer.write(data);
+}
 
 void main() {
   // ── RecordingMode parsing ──────────────────────────────────────────────
@@ -19,12 +48,16 @@ void main() {
 
     test('parses "detections"', () {
       expect(
-          recordingModeFromString('detections'), RecordingMode.detectionsOnly);
+        recordingModeFromString('detections'),
+        RecordingMode.detectionsOnly,
+      );
     });
 
     test('parses "detectionsOnly"', () {
-      expect(recordingModeFromString('detectionsOnly'),
-          RecordingMode.detectionsOnly);
+      expect(
+        recordingModeFromString('detectionsOnly'),
+        RecordingMode.detectionsOnly,
+      );
     });
 
     test('defaults to off for unknown', () {
@@ -89,10 +122,386 @@ void main() {
     });
 
     test('saveDetectionClip returns null when not recording', () async {
-      final result = await service.saveDetectionClip(
-        clipName: 'test-clip',
-      );
+      final result = await service.saveDetectionClip(clipName: 'test-clip');
       expect(result, isNull);
+    });
+
+    test('saveDetectionClips returns empty when not recording', () async {
+      final result = await service.saveDetectionClips(clipNames: ['a', 'b']);
+      expect(result, isEmpty);
+    });
+  });
+
+  // ── Clip naming ────────────────────────────────────────────────────────
+
+  group('detectionClipName', () {
+    final savedAt = DateTime.fromMillisecondsSinceEpoch(1700000000000);
+
+    test('slugs the species so each record owns its own file', () {
+      expect(
+        detectionClipName('Turdus merula', savedAt),
+        'clip_1700000000000000_0_Turdus_merula',
+      );
+    });
+
+    test('strips characters that are unsafe in file names', () {
+      expect(
+        detectionClipName('Sylvia (curruca)/x', savedAt),
+        'clip_1700000000000000_0_Sylvia_curruca_x',
+      );
+    });
+
+    test('two species in the same cycle get distinct names', () {
+      expect(
+        detectionClipName('Turdus merula', savedAt),
+        isNot(detectionClipName('Turdus pilaris', savedAt)),
+      );
+    });
+
+    test('successive re-cuts of one species get distinct names', () {
+      // A re-cut must write a new file before the old one is deleted, so the
+      // save time — not the detection time — has to drive the name.
+      expect(
+        detectionClipName('Turdus merula', savedAt),
+        isNot(
+          detectionClipName(
+            'Turdus merula',
+            savedAt.add(const Duration(seconds: 3)),
+          ),
+        ),
+      );
+    });
+
+    test('sequence disambiguates the same species in the same clock tick', () {
+      expect(
+        detectionClipName('Turdus merula', savedAt, sequence: 1),
+        isNot(detectionClipName('Turdus merula', savedAt, sequence: 2)),
+      );
+    });
+  });
+
+  // ── Peak confidence tracking ───────────────────────────────────────────
+
+  group('DetectionClipPeakTracker', () {
+    late DetectionClipPeakTracker tracker;
+
+    /// An ongoing detection asking whether its clip should be re-cut.
+    bool ongoing(
+      double candidate,
+      double current, {
+      String key = 'blackbird',
+      bool hasClip = true,
+    }) {
+      return tracker.needsClip(
+        key: key,
+        candidateConfidence: candidate,
+        currentConfidence: current,
+        hasClip: hasClip,
+        isNew: false,
+      );
+    }
+
+    /// A detection arriving for the first time this round.
+    bool arriving(double confidence, {bool hasClip = false}) {
+      return tracker.needsClip(
+        key: 'blackbird',
+        candidateConfidence: confidence,
+        currentConfidence: confidence,
+        hasClip: hasClip,
+        isNew: true,
+      );
+    }
+
+    setUp(() {
+      tracker = DetectionClipPeakTracker();
+      tracker.recordSaved('blackbird', 0.50);
+    });
+
+    test('a new detection always gets a first clip', () {
+      expect(arriving(0.20), isTrue);
+    });
+
+    test('a new detection that already carries a clip keeps it', () {
+      // ARU can be handed a record whose clip was cut elsewhere; re-cutting is
+      // for detections we have watched improve.
+      expect(arriving(0.90, hasClip: true), isFalse);
+    });
+
+    test('accumulates small gains from the confidence of the saved clip', () {
+      expect(ongoing(0.53, 0.50), isFalse);
+      // The record advanced to 0.53, but the clip still represents 0.50.
+      expect(ongoing(0.56, 0.53), isTrue);
+    });
+
+    test('accepts an improvement exactly on the rewrite boundary', () {
+      tracker.recordSaved('blackbird', 0.55);
+      expect(ongoing(0.60, 0.55), isTrue);
+    });
+
+    test('does not retry a failed replacement until the score improves', () {
+      expect(ongoing(0.56, 0.50), isTrue);
+      // No recordSaved call: the write failed.
+      expect(ongoing(0.56, 0.56), isFalse);
+      expect(ongoing(0.57, 0.56), isTrue);
+    });
+
+    test('missing clips retry on any new peak but not an unchanged score', () {
+      expect(ongoing(0.51, 0.50, key: 'robin', hasClip: false), isTrue);
+      expect(ongoing(0.50, 0.50, key: 'robin', hasClip: false), isFalse);
+    });
+
+    test('successful replacement advances the clip baseline', () {
+      tracker.recordSaved('blackbird', 0.56);
+      expect(ongoing(0.60, 0.56), isFalse);
+      expect(ongoing(0.61, 0.60), isTrue);
+    });
+
+    test('rejects stale, equal, and non-finite candidate scores', () {
+      for (final confidence in [0.49, 0.50, double.nan, double.infinity]) {
+        expect(ongoing(confidence, 0.50), isFalse, reason: '$confidence');
+      }
+      expect(arriving(double.nan), isFalse);
+    });
+
+    test('forget drops a closed detection\'s baseline', () {
+      // The clip on disk sits at 0.50, so 0.56 clears the margin.
+      expect(ongoing(0.56, 0.55), isTrue);
+
+      // The species disappears and later comes back. The next detection's
+      // clip has nothing to do with the old one, so it must be judged against
+      // its own score rather than the stale 0.50 baseline.
+      tracker.forget('blackbird');
+      expect(ongoing(0.56, 0.55), isFalse);
+    });
+
+    test('clear drops every baseline at a session boundary', () {
+      tracker.recordSaved('robin', 0.80);
+      expect(ongoing(0.56, 0.55), isTrue);
+      expect(ongoing(0.86, 0.85, key: 'robin'), isTrue);
+
+      tracker.clear();
+      expect(ongoing(0.56, 0.55), isFalse);
+      expect(ongoing(0.86, 0.85, key: 'robin'), isFalse);
+    });
+
+    test('keys are tracked independently', () {
+      tracker.recordSaved('robin', 0.80);
+      // Blackbird's clip sits at 0.50, robin's at 0.80 — the same candidate
+      // score means different things to each.
+      expect(ongoing(0.56, 0.55), isTrue);
+      expect(ongoing(0.82, 0.81, key: 'robin'), isFalse);
+    });
+
+    test('a zero delta re-cuts on every improvement', () {
+      final eager = DetectionClipPeakTracker(improvementDelta: 0);
+      eager.recordSaved('blackbird', 0.50);
+      expect(
+        eager.needsClip(
+          key: 'blackbird',
+          candidateConfidence: 0.5001,
+          currentConfidence: 0.50,
+          hasClip: true,
+          isNew: false,
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  // ── Peak-window clips ──────────────────────────────────────────────────
+
+  group('peak-window clips', () {
+    late Directory tmp;
+    late RingBuffer ringBuffer;
+    late RecordingService service;
+
+    setUp(() async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      tmp = await Directory.systemTemp.createTemp('recording_service_test');
+      PathProviderPlatform.instance = _FakePathProvider(tmp.path);
+
+      ringBuffer = RingBuffer(capacity: 1000);
+      service = RecordingService(
+        ringBuffer: ringBuffer,
+        sampleRate: 1000,
+        clipContextSeconds: 0,
+        windowSeconds: 1,
+      );
+      await service.startRecording(
+        sessionId: 'peak-clips',
+        mode: RecordingMode.detectionsOnly,
+        format: 'wav',
+      );
+      _writeTone(ringBuffer, 1000);
+    });
+
+    tearDown(() async {
+      service.dispose();
+      if (tmp.existsSync()) await tmp.delete(recursive: true);
+    });
+
+    test(
+      'saveDetectionClips writes one file per name from one snapshot',
+      () async {
+        final written = await service.saveDetectionClips(
+          clipNames: ['clip_a', 'clip_b', 'clip_c'],
+        );
+
+        expect(written.keys, containsAll(['clip_a', 'clip_b', 'clip_c']));
+        for (final path in written.values) {
+          expect(File(path).existsSync(), isTrue);
+        }
+        // Same audio snapshot for every species in the cycle.
+        final sizes = written.values.map((p) => File(p).lengthSync()).toSet();
+        expect(sizes, hasLength(1));
+      },
+    );
+
+    test('one failed batch entry does not discard successful clips', () async {
+      final invalidName = List.filled(300, 'x').join();
+      final written = await service.saveDetectionClips(
+        clipNames: ['valid_clip', invalidName],
+      );
+
+      expect(written.keys, ['valid_clip']);
+      expect(File(written['valid_clip']!).existsSync(), isTrue);
+    });
+
+    test('duplicate names are written only once', () async {
+      final written = await service.saveDetectionClips(
+        clipNames: ['same_clip', 'same_clip'],
+      );
+
+      expect(written, hasLength(1));
+      expect(File(written['same_clip']!).existsSync(), isTrue);
+    });
+
+    test('generated names stay unique within the same clock tick', () {
+      final savedAt = DateTime.fromMicrosecondsSinceEpoch(1700000000000000);
+      final first = service.nextDetectionClipName(
+        'Turdus merula',
+        savedAt: savedAt,
+      );
+      final second = service.nextDetectionClipName(
+        'Turdus merula',
+        savedAt: savedAt,
+      );
+
+      expect(second, isNot(first));
+    });
+
+    test('a delayed clip save cannot leak into the next session', () async {
+      await service.stopRecording();
+      service = RecordingService(
+        ringBuffer: ringBuffer,
+        sampleRate: 1000,
+        clipContextSeconds: 1,
+        windowSeconds: 1,
+      );
+      await service.startRecording(
+        sessionId: 'old-session',
+        mode: RecordingMode.detectionsOnly,
+        format: 'wav',
+      );
+
+      final pending = service.saveDetectionClips(clipNames: ['late_clip']);
+      await Future<void>.delayed(Duration.zero);
+      await service.stopRecording();
+      final newDir = await service.startRecording(
+        sessionId: 'new-session',
+        mode: RecordingMode.detectionsOnly,
+        format: 'wav',
+      );
+
+      expect(await pending, isEmpty);
+      expect(File('$newDir/late_clip.wav').existsSync(), isFalse);
+    });
+
+    test('saveDetectionClipsFor keys results by the caller\'s item', () async {
+      final written = await saveDetectionClipsFor<String>(
+        recordingService: service,
+        items: ['Turdus merula', 'Parus major'],
+        speciesOf: (name) => name,
+      );
+
+      expect(written.keys, containsAll(['Turdus merula', 'Parus major']));
+      expect(File(written['Turdus merula']!).existsSync(), isTrue);
+      expect(File(written['Parus major']!).existsSync(), isTrue);
+    });
+
+    test('saveDetectionClipsFor names files after the species', () async {
+      // ARU passes records rather than names, so the species has to come from
+      // [speciesOf] and not from the item's own toString.
+      final written = await saveDetectionClipsFor<int>(
+        recordingService: service,
+        items: [1, 2],
+        speciesOf: (id) => id == 1 ? 'Turdus merula' : 'Parus major',
+      );
+
+      expect(written[1], contains('Turdus_merula'));
+      expect(written[2], contains('Parus_major'));
+    });
+
+    test('saveDetectionClipsFor cuts one round from one snapshot', () async {
+      final written = await saveDetectionClipsFor<String>(
+        recordingService: service,
+        items: ['Turdus merula', 'Parus major', 'Erithacus rubecula'],
+        speciesOf: (name) => name,
+      );
+
+      expect(written, hasLength(3));
+      final sizes = written.values.map((p) => File(p).lengthSync()).toSet();
+      expect(sizes, hasLength(1));
+    });
+
+    test('saveDetectionClipsFor is a no-op for an empty round', () async {
+      final written = await saveDetectionClipsFor<String>(
+        recordingService: service,
+        items: const [],
+        speciesOf: (name) => name,
+      );
+      expect(written, isEmpty);
+    });
+
+    test(
+      're-cut writes the new clip and deletes the one it supersedes',
+      () async {
+        final first = await service.saveDetectionClip(clipName: 'peak_1');
+        expect(first, isNotNull);
+        expect(File(first!).existsSync(), isTrue);
+
+        final fresh = await service.saveDetectionClip(clipName: 'peak_2');
+        expect(fresh, isNotNull);
+        // Controllers publish this path before deleting the superseded file.
+        final second = fresh!;
+        await service.deleteClip(first);
+
+        expect(second, fresh);
+        expect(File(second).existsSync(), isTrue);
+        expect(File(first).existsSync(), isFalse);
+      },
+    );
+
+    test(
+      'a re-cut that writes nothing leaves the existing clip alone',
+      () async {
+        final first = await service.saveDetectionClip(clipName: 'peak_1');
+        expect(first, isNotNull);
+
+        // Silence stands in for any save that produces no file. There is no
+        // fresh path to adopt, so the caller keeps the clip it already has —
+        // the detection must never be left without audio.
+        ringBuffer.clear();
+        final fresh = await service.saveDetectionClip(clipName: 'peak_2');
+
+        expect(fresh, isNull);
+        expect(File(first!).existsSync(), isTrue);
+      },
+    );
+
+    test('deleteClip tolerates a missing file', () async {
+      await service.deleteClip('${tmp.path}/does-not-exist.wav');
+      await service.deleteClip(null);
     });
   });
 

--- a/test/features/survey/detection_sampler_test.dart
+++ b/test/features/survey/detection_sampler_test.dart
@@ -1,4 +1,4 @@
-﻿// =============================================================================
+// =============================================================================
 // Detection Sampler Tests — Clip-retention semantics for All / TopN / Smart
 // =============================================================================
 //
@@ -37,6 +37,17 @@ Future<DetectionRecord> _det(
     confidence: conf,
     timestamp: DateTime.utc(2025, 7, 1, 12).add(offset),
     audioClipPath: clipPath,
+    // Clips follow the confidence peak, so the window on disk sits a little
+    // after the detection started.
+    clipTimestamp:
+        clipPath == null
+            ? null
+            : DateTime.utc(
+              2025,
+              7,
+              1,
+              12,
+            ).add(offset + const Duration(seconds: 2)),
     latitude: latitude,
     longitude: longitude,
   );
@@ -84,12 +95,21 @@ void main() {
   group('SamplingMode.topN', () {
     test('keeps up to N clips per species', () async {
       final sampler = DetectionSampler(mode: SamplingMode.topN, topN: 2);
-      final d1 =
-          await _det('Parus major', 0.9, offset: const Duration(seconds: 0));
-      final d2 =
-          await _det('Parus major', 0.8, offset: const Duration(seconds: 3));
-      final d3 =
-          await _det('Parus major', 0.7, offset: const Duration(seconds: 6));
+      final d1 = await _det(
+        'Parus major',
+        0.9,
+        offset: const Duration(seconds: 0),
+      );
+      final d2 = await _det(
+        'Parus major',
+        0.8,
+        offset: const Duration(seconds: 3),
+      );
+      final d3 = await _det(
+        'Parus major',
+        0.7,
+        offset: const Duration(seconds: 6),
+      );
 
       expect(await sampler.onRecordClosed(d1), isTrue);
       expect(await sampler.onRecordClosed(d2), isTrue);
@@ -104,12 +124,21 @@ void main() {
 
     test('evicts weakest clip when a better record arrives', () async {
       final sampler = DetectionSampler(mode: SamplingMode.topN, topN: 2);
-      final d1 =
-          await _det('Parus major', 0.5, offset: const Duration(seconds: 0));
-      final d2 =
-          await _det('Parus major', 0.6, offset: const Duration(seconds: 3));
-      final d3 =
-          await _det('Parus major', 0.9, offset: const Duration(seconds: 6));
+      final d1 = await _det(
+        'Parus major',
+        0.5,
+        offset: const Duration(seconds: 0),
+      );
+      final d2 = await _det(
+        'Parus major',
+        0.6,
+        offset: const Duration(seconds: 3),
+      );
+      final d3 = await _det(
+        'Parus major',
+        0.9,
+        offset: const Duration(seconds: 6),
+      );
 
       await sampler.onRecordClosed(d1);
       await sampler.onRecordClosed(d2);
@@ -119,6 +148,33 @@ void main() {
       expect(d2.audioClipPath, isNotNull);
       expect(d3.audioClipPath, isNotNull);
       expect(sampler.keptClipCount, 2);
+    });
+
+    test('an evicted record stops advertising a clip window', () async {
+      // The window a clip was cut from describes a file that no longer
+      // exists once the clip is dropped; leaving it set would let session
+      // review label a row with audio it cannot play.
+      final sampler = DetectionSampler(mode: SamplingMode.topN, topN: 1);
+      final kept = await _det(
+        'Parus major',
+        0.9,
+        offset: const Duration(seconds: 0),
+      );
+      final dropped = await _det(
+        'Parus major',
+        0.4,
+        offset: const Duration(seconds: 3),
+      );
+
+      await sampler.onRecordClosed(kept);
+      await sampler.onRecordClosed(dropped);
+
+      expect(dropped.audioClipPath, isNull);
+      expect(dropped.clipTimestamp, isNull);
+      // The record itself is untouched — the detection still happened.
+      expect(dropped.timestamp, isNotNull);
+      expect(kept.audioClipPath, isNotNull);
+      expect(kept.clipTimestamp, isNotNull);
     });
 
     test('tracks species independently', () async {
@@ -144,8 +200,11 @@ void main() {
     test('deletes evicted file from disk', () async {
       final sampler = DetectionSampler(mode: SamplingMode.topN, topN: 1);
       final d1 = await _det('Parus major', 0.5);
-      final d2 =
-          await _det('Parus major', 0.9, offset: const Duration(seconds: 3));
+      final d2 = await _det(
+        'Parus major',
+        0.9,
+        offset: const Duration(seconds: 3),
+      );
       final d1Path = d1.audioClipPath!;
 
       await sampler.onRecordClosed(d1);
@@ -166,12 +225,20 @@ void main() {
         timeThresholdSeconds: 120,
       );
 
-      final d1 = await _det('Parus major', 0.9,
-          offset: const Duration(seconds: 0), latitude: 52.0, longitude: 13.0);
-      final d2 = await _det('Parus major', 0.8,
-          offset: const Duration(seconds: 30),
-          latitude: 52.1,
-          longitude: 13.0); // ~11 km north
+      final d1 = await _det(
+        'Parus major',
+        0.9,
+        offset: const Duration(seconds: 0),
+        latitude: 52.0,
+        longitude: 13.0,
+      );
+      final d2 = await _det(
+        'Parus major',
+        0.8,
+        offset: const Duration(seconds: 30),
+        latitude: 52.1,
+        longitude: 13.0,
+      ); // ~11 km north
 
       expect(await sampler.onRecordClosed(d1), isTrue);
       expect(await sampler.onRecordClosed(d2), isTrue);
@@ -186,12 +253,20 @@ void main() {
         timeThresholdSeconds: 120,
       );
 
-      final d1 = await _det('Parus major', 0.5,
-          offset: const Duration(seconds: 0), latitude: 52.0, longitude: 13.0);
-      final d2 = await _det('Parus major', 0.9,
-          offset: const Duration(seconds: 30),
-          latitude: 52.0001,
-          longitude: 13.0001); // ~14 m away
+      final d1 = await _det(
+        'Parus major',
+        0.5,
+        offset: const Duration(seconds: 0),
+        latitude: 52.0,
+        longitude: 13.0,
+      );
+      final d2 = await _det(
+        'Parus major',
+        0.9,
+        offset: const Duration(seconds: 30),
+        latitude: 52.0001,
+        longitude: 13.0001,
+      ); // ~14 m away
 
       await sampler.onRecordClosed(d1);
       expect(await sampler.onRecordClosed(d2), isTrue);
@@ -208,10 +283,20 @@ void main() {
         timeThresholdSeconds: 120,
       );
 
-      final d1 = await _det('Parus major', 0.9,
-          offset: Duration.zero, latitude: 52.0, longitude: 13.0);
-      final d2 = await _det('Parus major', 0.8,
-          offset: const Duration(minutes: 5), latitude: 52.0, longitude: 13.0);
+      final d1 = await _det(
+        'Parus major',
+        0.9,
+        offset: Duration.zero,
+        latitude: 52.0,
+        longitude: 13.0,
+      );
+      final d2 = await _det(
+        'Parus major',
+        0.8,
+        offset: const Duration(minutes: 5),
+        latitude: 52.0,
+        longitude: 13.0,
+      );
 
       expect(await sampler.onRecordClosed(d1), isTrue);
       expect(await sampler.onRecordClosed(d2), isTrue);
@@ -226,10 +311,20 @@ void main() {
         timeThresholdSeconds: 120,
       );
 
-      final d1 = await _det('Parus major', 0.9,
-          offset: Duration.zero, latitude: 52.0, longitude: 13.0);
-      final d2 = await _det('Parus major', 0.3,
-          offset: const Duration(seconds: 30), latitude: 52.0, longitude: 13.0);
+      final d1 = await _det(
+        'Parus major',
+        0.9,
+        offset: Duration.zero,
+        latitude: 52.0,
+        longitude: 13.0,
+      );
+      final d2 = await _det(
+        'Parus major',
+        0.3,
+        offset: const Duration(seconds: 30),
+        latitude: 52.0,
+        longitude: 13.0,
+      );
 
       await sampler.onRecordClosed(d1);
       expect(await sampler.onRecordClosed(d2), isFalse);
@@ -238,31 +333,48 @@ void main() {
       expect(sampler.keptClipCount, 1);
     });
 
-    test('still enforces per-species topN when spots are all distinct',
-        () async {
-      final sampler = DetectionSampler(
-        mode: SamplingMode.smart,
-        topN: 2,
-        distanceThresholdMeters: 500,
-        timeThresholdSeconds: 120,
-      );
+    test(
+      'still enforces per-species topN when spots are all distinct',
+      () async {
+        final sampler = DetectionSampler(
+          mode: SamplingMode.smart,
+          topN: 2,
+          distanceThresholdMeters: 500,
+          timeThresholdSeconds: 120,
+        );
 
-      final d1 = await _det('Parus major', 0.5,
-          offset: Duration.zero, latitude: 52.0, longitude: 13.0);
-      final d2 = await _det('Parus major', 0.6,
-          offset: const Duration(minutes: 10), latitude: 52.5, longitude: 13.0);
-      final d3 = await _det('Parus major', 0.9,
-          offset: const Duration(minutes: 20), latitude: 53.0, longitude: 13.0);
+        final d1 = await _det(
+          'Parus major',
+          0.5,
+          offset: Duration.zero,
+          latitude: 52.0,
+          longitude: 13.0,
+        );
+        final d2 = await _det(
+          'Parus major',
+          0.6,
+          offset: const Duration(minutes: 10),
+          latitude: 52.5,
+          longitude: 13.0,
+        );
+        final d3 = await _det(
+          'Parus major',
+          0.9,
+          offset: const Duration(minutes: 20),
+          latitude: 53.0,
+          longitude: 13.0,
+        );
 
-      await sampler.onRecordClosed(d1);
-      await sampler.onRecordClosed(d2);
-      expect(await sampler.onRecordClosed(d3), isTrue);
+        await sampler.onRecordClosed(d1);
+        await sampler.onRecordClosed(d2);
+        expect(await sampler.onRecordClosed(d3), isTrue);
 
-      expect(d1.audioClipPath, isNull);
-      expect(d2.audioClipPath, isNotNull);
-      expect(d3.audioClipPath, isNotNull);
-      expect(sampler.keptClipCount, 2);
-    });
+        expect(d1.audioClipPath, isNull);
+        expect(d2.audioClipPath, isNotNull);
+        expect(d3.audioClipPath, isNotNull);
+        expect(sampler.keptClipCount, 2);
+      },
+    );
 
     test('missing GPS falls back to time-only same-spot check', () async {
       final sampler = DetectionSampler(
@@ -274,8 +386,11 @@ void main() {
 
       // No GPS on either record; within the time window â†’ same spot.
       final d1 = await _det('Parus major', 0.5, offset: Duration.zero);
-      final d2 =
-          await _det('Parus major', 0.9, offset: const Duration(seconds: 30));
+      final d2 = await _det(
+        'Parus major',
+        0.9,
+        offset: const Duration(seconds: 30),
+      );
 
       await sampler.onRecordClosed(d1);
       expect(await sampler.onRecordClosed(d2), isTrue);
@@ -283,33 +398,55 @@ void main() {
       expect(d2.audioClipPath, isNotNull);
     });
 
-    test('admits same-spot clips freely until topN, then applies rivalry',
-        () async {
-      final sampler = DetectionSampler(
-        mode: SamplingMode.smart,
-        topN: 3,
-        distanceThresholdMeters: 250,
-        timeThresholdSeconds: 120,
-      );
+    test(
+      'admits same-spot clips freely until topN, then applies rivalry',
+      () async {
+        final sampler = DetectionSampler(
+          mode: SamplingMode.smart,
+          topN: 3,
+          distanceThresholdMeters: 250,
+          timeThresholdSeconds: 120,
+        );
 
-      // Three same-spot detections all within the time window. All should be
-      // kept because rivalry doesn't fire until the topN slots are full.
-      final d1 = await _det('Parus major', 0.5,
-          offset: Duration.zero, latitude: 52.0, longitude: 13.0);
-      final d2 = await _det('Parus major', 0.6,
-          offset: const Duration(seconds: 10), latitude: 52.0, longitude: 13.0);
-      final d3 = await _det('Parus major', 0.7,
-          offset: const Duration(seconds: 20), latitude: 52.0, longitude: 13.0);
-      // Fourth same-spot detection: topN is now full, so rivalry fires and
-      // this weaker clip loses to the weakest already-kept clip.
-      final d4 = await _det('Parus major', 0.4,
-          offset: const Duration(seconds: 30), latitude: 52.0, longitude: 13.0);
+        // Three same-spot detections all within the time window. All should be
+        // kept because rivalry doesn't fire until the topN slots are full.
+        final d1 = await _det(
+          'Parus major',
+          0.5,
+          offset: Duration.zero,
+          latitude: 52.0,
+          longitude: 13.0,
+        );
+        final d2 = await _det(
+          'Parus major',
+          0.6,
+          offset: const Duration(seconds: 10),
+          latitude: 52.0,
+          longitude: 13.0,
+        );
+        final d3 = await _det(
+          'Parus major',
+          0.7,
+          offset: const Duration(seconds: 20),
+          latitude: 52.0,
+          longitude: 13.0,
+        );
+        // Fourth same-spot detection: topN is now full, so rivalry fires and
+        // this weaker clip loses to the weakest already-kept clip.
+        final d4 = await _det(
+          'Parus major',
+          0.4,
+          offset: const Duration(seconds: 30),
+          latitude: 52.0,
+          longitude: 13.0,
+        );
 
-      expect(await sampler.onRecordClosed(d1), isTrue);
-      expect(await sampler.onRecordClosed(d2), isTrue);
-      expect(await sampler.onRecordClosed(d3), isTrue);
-      expect(await sampler.onRecordClosed(d4), isFalse);
-      expect(sampler.keptClipCount, 3);
-    });
+        expect(await sampler.onRecordClosed(d1), isTrue);
+        expect(await sampler.onRecordClosed(d2), isTrue);
+        expect(await sampler.onRecordClosed(d3), isTrue);
+        expect(await sampler.onRecordClosed(d4), isFalse);
+        expect(sampler.keptClipCount, 3);
+      },
+    );
   });
 }


### PR DESCRIPTION
Introduce functionality to save detection clips based on their peak score, enhancing the audio processing capabilities. Update the version number to 0.19.3 to reflect these changes.