### PR TITLE
Add full screen survey map feature and fix map markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The map during an active survey can now be opened full screen, from the expand button in its top-right corner. The small map keeps following your position as before; the full screen one hands the camera to you, so panning and zooming to look ahead along a transect no longer gets undone by the next GPS fix. A button in the bottom-left corner recenters on your current position when you want it back.
+
+### Fixed
+
+- Detections without an audio clip no longer draw a larger pin on the survey map than the ones with a clip. Their marker was being stretched to fill the space reserved for the largest possible pin, which made a silent detection the most prominent thing on the map. Silent markers now render at their intended size, slightly smaller than a marker with a clip so the play badge on the latter doesn't make it look bigger — the two read as the same size, and audio still stands out through color rather than size.
+- Playing a detection from the full screen survey map in Session Review now keeps its marker in view. The map centered on the detection and the player sheet then covered it; the map now offsets the marker above center, so you can see which detection you are listening to.
+
 ## [0.19.3] - 2026-07-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.3] - 2026-07-29
+
 ### Added
 
 - The map during an active survey can now be opened full screen, from the expand button in its top-right corner. The small map keeps following your position as before; the full screen one hands the camera to you, so panning and zooming to look ahead along a transect no longer gets undone by the next GPS fix. A button in the bottom-left corner recenters on your current position when you want it back.
@@ -15,11 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Detections without an audio clip no longer draw a larger pin on the survey map than the ones with a clip. Their marker was being stretched to fill the space reserved for the largest possible pin, which made a silent detection the most prominent thing on the map. Silent markers now render at their intended size, slightly smaller than a marker with a clip so the play badge on the latter doesn't make it look bigger — the two read as the same size, and audio still stands out through color rather than size.
 - Playing a detection from the full screen survey map in Session Review now keeps its marker in view. The map centered on the detection and the player sheet then covered it; the map now offsets the marker above center, so you can see which detection you are listening to.
-
-## [0.19.3] - 2026-07-29
-
-### Fixed
-
 - Detection clips now come from the strongest part of a detection instead of its first moment. A detection lasts as long as the species keeps being heard — often many analysis windows — but a clip holds one window, and the app was always keeping the first one. Since birds typically enter just above the confidence threshold and peak a few seconds later, the saved audio was usually the weakest evidence of the detection and did not match the confidence shown next to it. The clip is now re-cut whenever a detection reaches a noticeably higher score, so what you end up with is the best window the app heard. This also makes **Top N** and **Smart** clip subsampling keep the right clips, since they rank detections by that peak score. Use the clip padding setting to keep more audio around the window. Live, Survey and ARU deployments all follow the same rule, and when several species peak in the same moment their clips are now all cut from that moment instead of drifting later one by one — which is what ARU deployments used to do on a busy dawn chorus.
 - Session Review now shows the right times for clip-only sessions. A detection can run for half a minute while the clip saved for it holds a single analysis window plus your clip padding — so the start-to-end time on each row was describing the bird, not the audio, and the two no longer lined up once clips started following the strongest moment. Rows in sessions without a full recording now show the span the clip actually covers, and the full time the species was heard moved to the detection's player sheet, where it can't be mistaken for the clip length. Sessions with a full recording are unchanged. This also corrects the detection offsets written into Raven and CSV exports for clip-only sessions, which had been pointing at the moment the bird was first heard rather than the moment the clip was cut. Older clips without peak metadata stay anchored to the first detection window.
 - Every detection now owns its own clip file. When several species appeared in the same moment they used to share a single file, so **Top N** and **Smart** subsampling could delete a clip that another detection still pointed at, leaving that detection with a broken play button. A species that was already being heard could also pick up a clip that had been cut for a different species entirely. Both are fixed. The trade-off is more audio on disk when many species are heard at once — subsampling still trims it back at the end of a detection.

--- a/lib/features/history/session_review_screen.dart
+++ b/lib/features/history/session_review_screen.dart
@@ -4886,6 +4886,10 @@ class _FullscreenSurveyMapScreenState
             fitAllPoints: true,
             highlightedDetection: _highlight,
             onMarkerTap: _onMarkerTap,
+            // Tapping a marker opens the clip player sheet over the bottom
+            // half of the screen. Raise the focused detection above center
+            // so the sheet never covers the marker being played.
+            highlightVerticalBias: 0.25,
           ),
           // Persistent filter chip — promotes the AppBar action to a
           // first-class on-map affordance so the filter is discoverable

--- a/lib/features/survey/survey_live_screen.dart
+++ b/lib/features/survey/survey_live_screen.dart
@@ -21,6 +21,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:birdnet_live/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -183,6 +184,43 @@ class _SurveyLiveScreenState extends ConsumerState<SurveyLiveScreen>
         snackBarController.close();
       } catch (_) {}
     });
+  }
+
+  /// Center used before the first GPS fix lands, so the map isn't stranded
+  /// over the default world view while the survey warms up.
+  LatLng? get _mapFallbackCenter =>
+      widget.startLatitude != null && widget.startLongitude != null
+          ? LatLng(widget.startLatitude!, widget.startLongitude!)
+          : null;
+
+  /// Open the clip player for a live detection marker. Shared by the inline
+  /// map tab and the fullscreen map so both surfaces behave identically.
+  /// Returns the sheet's future so callers can refresh once it closes.
+  Future<void> _openLiveClipPlayer(DetectionRecord detection) {
+    return showClipPlayerSheet(
+      context,
+      detection: detection,
+      session: ref.read(surveySessionProvider),
+      onConfirmChanged: () {
+        if (mounted) setState(() {});
+      },
+      onDelete: () => _deleteLiveDetectionWithUndo(detection),
+    );
+  }
+
+  /// Push the fullscreen live map. Unlike the inline map it does not
+  /// auto-follow the GPS position — the user pans and zooms freely for
+  /// navigation and taps the recenter button to jump back.
+  void _openFullscreenLiveMap() {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder:
+            (_) => _FullscreenLiveSurveyMapScreen(
+              fallbackCenter: _mapFallbackCenter,
+              onMarkerTap: _openLiveClipPlayer,
+            ),
+      ),
+    );
   }
 
   /// Open the species picker and, on confirm, log a manual observation.
@@ -904,27 +942,47 @@ class _SurveyLiveScreenState extends ConsumerState<SurveyLiveScreen>
       controller: _tabController,
       physics: const NeverScrollableScrollPhysics(),
       children: [
-        SurveyMapWidget(
-          gpsTrack: controller.gpsTracker?.track ?? [],
-          detections: session?.detections ?? [],
-          initialCenter:
-              widget.startLatitude != null && widget.startLongitude != null
-                  ? LatLng(widget.startLatitude!, widget.startLongitude!)
-                  : null,
-          // Tapping a marker that has a kept clip opens the same
-          // player sheet as the post-session map - so the live and
-          // review surfaces feel like one continuous experience.
-          onMarkerTap: (detection) {
-            showClipPlayerSheet(
-              context,
-              detection: detection,
-              session: session,
-              onConfirmChanged: () {
-                if (mounted) setState(() {});
-              },
-              onDelete: () => _deleteLiveDetectionWithUndo(detection),
-            );
-          },
+        Stack(
+          children: [
+            Positioned.fill(
+              child: SurveyMapWidget(
+                gpsTrack: controller.gpsTracker?.track ?? [],
+                detections: session?.detections ?? [],
+                initialCenter: _mapFallbackCenter,
+                // Tapping a marker that has a kept clip opens the same
+                // player sheet as the post-session map - so the live and
+                // review surfaces feel like one continuous experience.
+                onMarkerTap: (detection) => _openLiveClipPlayer(detection),
+              ),
+            ),
+            // Expand affordance mirroring Session Review's inline map: the
+            // minimized map keeps auto-following the current position, the
+            // fullscreen one hands panning and zooming to the user.
+            Positioned(
+              top: 8,
+              right: 8,
+              child: Material(
+                color: theme.colorScheme.surface.withValues(alpha: 0.8),
+                shape: const CircleBorder(),
+                child: InkWell(
+                  customBorder: const CircleBorder(),
+                  onTap: _openFullscreenLiveMap,
+                  child: Tooltip(
+                    message: l10n.surveyMapFullscreen,
+                    child: Padding(
+                      padding: const EdgeInsets.all(6),
+                      child: Icon(
+                        AppIcons.fullscreen,
+                        size: 20,
+                        color: theme.colorScheme.onSurface,
+                        semanticLabel: l10n.surveyMapFullscreen,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
         ),
         _SurveySpectrogram(ringBuffer: ringBuffer, isActive: isActive),
         _SurveySummaryTab(session: session),
@@ -1016,6 +1074,106 @@ class _SurveyLiveScreenState extends ConsumerState<SurveyLiveScreen>
         ],
         const SizedBox(height: 16),
       ],
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fullscreen Live Survey Map
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Fullscreen version of the live survey map.
+///
+/// The inline map tab keeps the camera pinned to the latest GPS fix, which is
+/// what you want in a glanceable strip but makes the map useless for looking
+/// ahead. This screen turns auto-follow off so the map behaves like a normal
+/// navigation map — pan and zoom stay exactly where the user put them, no
+/// matter how many GPS points arrive — with a recenter button to jump back to
+/// the current position on demand.
+class _FullscreenLiveSurveyMapScreen extends ConsumerStatefulWidget {
+  const _FullscreenLiveSurveyMapScreen({
+    required this.onMarkerTap,
+    this.fallbackCenter,
+  });
+
+  /// Opens the clip player for a tapped detection. Owned by the live screen
+  /// so deletes and confirmations mutate the one running session.
+  final Future<void> Function(DetectionRecord detection) onMarkerTap;
+
+  /// Where to center before the first GPS fix arrives.
+  final LatLng? fallbackCenter;
+
+  @override
+  ConsumerState<_FullscreenLiveSurveyMapScreen> createState() =>
+      _FullscreenLiveSurveyMapScreenState();
+}
+
+class _FullscreenLiveSurveyMapScreenState
+    extends ConsumerState<_FullscreenLiveSurveyMapScreen> {
+  /// Owned here (rather than inside [SurveyMapWidget]) so the recenter
+  /// button can drive the camera.
+  final MapController _mapController = MapController();
+
+  /// Set once the map has been laid out at least once — [MapController]
+  /// throws when used before that.
+  bool _mapReady = false;
+
+  @override
+  void dispose() {
+    _mapController.dispose();
+    super.dispose();
+  }
+
+  void _recenter() {
+    if (!_mapReady) return;
+    final track = ref.read(surveyControllerProvider).gpsTracker?.track;
+    final target =
+        track != null && track.isNotEmpty
+            ? LatLng(track.last.latitude, track.last.longitude)
+            : widget.fallbackCenter;
+    if (target == null) return;
+    // Keep the user's zoom when they're already close in; only pull in when
+    // they've zoomed out far enough that the position marker would be lost.
+    final zoom = _mapController.camera.zoom;
+    _mapController.move(target, zoom < 16 ? 17 : zoom);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    // Same rebuild signal the live dashboard uses: the session object is
+    // mutated in place, so the per-cycle detections provider is what tells us
+    // new markers and GPS points have landed.
+    ref.watch(surveyDetectionsProvider);
+    final session = ref.watch(surveySessionProvider);
+    final controller = ref.read(surveyControllerProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.surveyTrackMap)),
+      body: SurveyMapWidget(
+        mapController: _mapController,
+        gpsTrack: controller.gpsTracker?.track ?? const [],
+        detections: session?.detections ?? const [],
+        // Free navigation: never yank the camera back to the latest fix.
+        autoFollow: false,
+        initialCenter: widget.fallbackCenter,
+        onMarkerTap: (detection) async {
+          await widget.onMarkerTap(detection);
+          // The sheet can delete the detection; rebuild so its marker goes.
+          if (mounted) setState(() {});
+        },
+        onCameraMove: (_) {
+          if (!_mapReady) _mapReady = true;
+        },
+      ),
+      floatingActionButton: FloatingActionButton.small(
+        onPressed: _recenter,
+        tooltip: l10n.surveyMapRecenter,
+        child: const Icon(AppIcons.myLocation),
+      ),
+      // Bottom-left: the OpenStreetMap attribution badge owns the
+      // bottom-right corner of every map in the app.
+      floatingActionButtonLocation: FloatingActionButtonLocation.startFloat,
     );
   }
 }

--- a/lib/features/survey/widgets/survey_map_widget.dart
+++ b/lib/features/survey/widgets/survey_map_widget.dart
@@ -67,6 +67,8 @@ class SurveyMapWidget extends ConsumerStatefulWidget {
     this.initialCenter,
     this.interactionOptions,
     this.tileLayerBuilder,
+    this.mapController,
+    this.highlightVerticalBias = 0,
   });
 
   /// GPS track points.
@@ -103,12 +105,27 @@ class SurveyMapWidget extends ConsumerStatefulWidget {
   /// exercising marker and cluster semantics.
   final WidgetBuilder? tileLayerBuilder;
 
+  /// Optional externally owned map controller. Hosts pass one when they need
+  /// to drive the camera themselves (e.g. the fullscreen live map's
+  /// "recenter on current position" button). When null the widget creates
+  /// and owns its own controller.
+  final MapController? mapController;
+
+  /// Fraction of the map's height by which a newly highlighted detection is
+  /// raised above the camera center. 0 centers the detection exactly; 0.25
+  /// puts it a quarter of the viewport above center so a bottom sheet
+  /// (the clip player) can't cover the marker the user just tapped.
+  final double highlightVerticalBias;
+
   @override
   ConsumerState<SurveyMapWidget> createState() => _SurveyMapWidgetState();
 }
 
 class _SurveyMapWidgetState extends ConsumerState<SurveyMapWidget> {
-  final MapController _mapController = MapController();
+  /// Owned only when the host didn't supply one — an externally passed
+  /// controller outlives this state and must not be disposed here.
+  late final MapController _mapController =
+      widget.mapController ?? MapController();
   bool? _hasConsent;
   int _lastTrackLength = 0;
   bool _initialFitDone = false;
@@ -146,12 +163,19 @@ class _SurveyMapWidgetState extends ConsumerState<SurveyMapWidget> {
     super.didUpdateWidget(oldWidget);
     if (!_mapReady) return;
 
-    // Handle highlight change — center on highlighted detection.
+    // Every camera move below is deferred to the end of the frame.
+    // `didUpdateWidget` runs *during* build, and `MapController.move`
+    // synchronously fires `onPositionChanged` — which calls `setState` when
+    // the zoom crosses the dot/silhouette threshold. Calling that mid-build
+    // throws, which used to abort the highlight move half-way through (the
+    // first tap after opening the map landed on the plain center, skipping
+    // the vertical bias, because only that first tap crossed the threshold).
     if (widget.highlightedDetection != null &&
         widget.highlightedDetection != oldWidget.highlightedDetection) {
       final d = widget.highlightedDetection!;
       if (d.latitude != null && d.longitude != null) {
-        _mapController.move(LatLng(d.latitude!, d.longitude!), 18);
+        final target = LatLng(d.latitude!, d.longitude!);
+        _afterFrame(() => _moveToHighlight(target));
       }
       return;
     }
@@ -163,11 +187,46 @@ class _SurveyMapWidgetState extends ConsumerState<SurveyMapWidget> {
         widget.gpsTrack.isNotEmpty) {
       _lastTrackLength = widget.gpsTrack.length;
       final last = widget.gpsTrack.last;
-      _mapController.move(
-        LatLng(last.latitude, last.longitude),
-        _mapController.camera.zoom,
-      );
+      _afterFrame(() {
+        _mapController.move(
+          LatLng(last.latitude, last.longitude),
+          _mapController.camera.zoom,
+        );
+      });
     }
+  }
+
+  /// Run [action] once the current frame is done, skipping it if this state
+  /// or the map went away in the meantime.
+  void _afterFrame(VoidCallback action) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted && _mapReady) action();
+    });
+  }
+
+  /// Center the camera on a highlighted detection at [zoom], honouring
+  /// [SurveyMapWidget.highlightVerticalBias].
+  ///
+  /// With a non-zero bias we move twice: once to put the detection at the
+  /// exact center (which gives us a camera whose projection we can query),
+  /// then again onto the point that sits `bias × height` pixels *below* the
+  /// detection. The detection ends up that far above center, clear of the
+  /// clip player sheet that slides in over the bottom of the map. Going
+  /// through [MapCamera.screenOffsetToLatLng] keeps the math correct at any
+  /// zoom, latitude, and map rotation.
+  void _moveToHighlight(LatLng target, {double zoom = 18}) {
+    _mapController.move(target, zoom);
+    final bias = widget.highlightVerticalBias;
+    if (bias <= 0) return;
+    final camera = _mapController.camera;
+    final size = camera.nonRotatedSize;
+    if (!size.height.isFinite || size.height <= 0) return;
+    _mapController.move(
+      camera.screenOffsetToLatLng(
+        size.center(Offset.zero) + Offset(0, size.height * bias),
+      ),
+      zoom,
+    );
   }
 
   void _checkConsent() {
@@ -326,9 +385,10 @@ class _SurveyMapWidgetState extends ConsumerState<SurveyMapWidget> {
           // Uniform bounding box so audio and silent markers visually match —
           // the corner play badge needs a few extra pixels of padding either
           // way. Slightly larger than the pre-#33 sizes so silhouettes stay
-          // legible when zoomed in.
-          width: isHighlighted ? 56 : 48,
-          height: isHighlighted ? 56 : 48,
+          // legible when zoomed in, and roomy enough for a highlighted
+          // audio marker that also carries the confirmed checkmark.
+          width: isHighlighted ? 60 : 48,
+          height: isHighlighted ? 60 : 48,
           child: SurveyMapMarkerSemantics(
             label: displayName,
             confidence: det.confidence,
@@ -339,13 +399,22 @@ class _SurveyMapWidgetState extends ConsumerState<SurveyMapWidget> {
                 widget.onMarkerTap != null
                     ? () => widget.onMarkerTap!(det)
                     : null,
-            child: _SpeciesMarker(
-              scientificName: det.scientificName,
-              confidence: det.confidence,
-              isHighlighted: isHighlighted,
-              hasAudio: hasAudio,
-              useDot: useDot,
-              isConfirmed: det.isConfirmed,
+            // The marker box hands its child *tight* constraints, which a
+            // bare sized Container silently inflates to fill (a Container's
+            // width/height lose to tight incoming constraints). That made
+            // silent markers render at the full box size instead of their
+            // intended diameter — and therefore bigger than the audio
+            // markers, whose inner Center already shielded them. Centering
+            // here loosens the constraints for every marker form at once.
+            child: Center(
+              child: _SpeciesMarker(
+                scientificName: det.scientificName,
+                confidence: det.confidence,
+                isHighlighted: isHighlighted,
+                hasAudio: hasAudio,
+                useDot: useDot,
+                isConfirmed: det.isConfirmed,
+              ),
             ),
           ),
         ),
@@ -775,13 +844,14 @@ class _SpeciesMarker extends ConsumerWidget {
       );
     }
 
-    // Silent (no-audio) markers are noticeably smaller than audio ones so
-    // the visual hierarchy reads at a glance — audio detections are the
-    // primary content, silent ones are context. The highlighted size is also
-    // shrunk for silent markers so a stray rebuild can never make a silent
-    // marker visually outweigh an unhighlighted audio one.
+    // Silent (no-audio) markers use a slightly smaller circle than audio
+    // ones so the two forms read as the *same* size on the map: an audio
+    // marker carries a play badge that overhangs its avatar, and without
+    // the 4 px handicap that badge makes it look like the bigger pin.
+    // Ranking still comes through via desaturation, opacity, and the
+    // neutral border — not size.
     final size =
-        isHighlighted ? (hasAudio ? 48.0 : 36.0) : (hasAudio ? 36.0 : 24.0);
+        isHighlighted ? (hasAudio ? 48.0 : 44.0) : (hasAudio ? 36.0 : 32.0);
 
     final taxonomyAsync = ref.watch(taxonomyServiceProvider);
     final path =

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -713,6 +713,8 @@
   "surveyTrackMap": "Trasa Survey",
   "surveyMapFilterTitle": "Zobrazit na mapě",
   "surveyMapFilterTooltip": "Filtrovat značky",
+  "surveyMapFullscreen": "Mapa na celou obrazovku",
+  "surveyMapRecenter": "Vycentrovat na aktuální pozici",
   "surveyMapFilterChipAll": "Všechny detekce",
   "surveyMapFilterAll": "Všechny detekce",
   "surveyMapFilterWithAudio": "S audiozaznamem",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -729,6 +729,8 @@
   "surveyTrackMap": "Survey-Strecke",
   "surveyMapFilterTitle": "Auf Karte anzeigen",
   "surveyMapFilterTooltip": "Markierungen filtern",
+  "surveyMapFullscreen": "Karte im Vollbild",
+  "surveyMapRecenter": "Auf aktuelle Position zentrieren",
   "surveyMapFilterChipAll": "Alle Detektionen",
   "surveyMapFilterAll": "Alle Detektionen",
   "surveyMapFilterWithAudio": "Mit Audioclip",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3199,6 +3199,14 @@
   "@surveyMapFilterTooltip": {
     "description": "Tooltip for the survey map filter button"
   },
+  "surveyMapFullscreen": "Full screen map",
+  "@surveyMapFullscreen": {
+    "description": "Tooltip for the button that opens the survey map full screen"
+  },
+  "surveyMapRecenter": "Center on current position",
+  "@surveyMapRecenter": {
+    "description": "Tooltip for the button that recenters the full screen live survey map on the current GPS position"
+  },
   "surveyMapFilterChipAll": "All detections",
   "@surveyMapFilterChipAll": {
     "description": "Persistent map filter chip label when no filter is active"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -713,6 +713,8 @@
   "surveyTrackMap": "Recorrido del Survey",
   "surveyMapFilterTitle": "Mostrar en el mapa",
   "surveyMapFilterTooltip": "Filtrar marcadores",
+  "surveyMapFullscreen": "Mapa en pantalla completa",
+  "surveyMapRecenter": "Centrar en la posición actual",
   "surveyMapFilterChipAll": "Todas las detecciones",
   "surveyMapFilterAll": "Todas las detecciones",
   "surveyMapFilterWithAudio": "Con clip de audio",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -713,6 +713,8 @@
   "surveyTrackMap": "Tracé du relevé",
   "surveyMapFilterTitle": "Afficher sur la carte",
   "surveyMapFilterTooltip": "Filtrer les marqueurs",
+  "surveyMapFullscreen": "Carte en plein écran",
+  "surveyMapRecenter": "Centrer sur la position actuelle",
   "surveyMapFilterChipAll": "Toutes les détections",
   "surveyMapFilterAll": "Toutes les détections",
   "surveyMapFilterWithAudio": "Avec clip audio",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -713,6 +713,8 @@
   "surveyTrackMap": "Percorso del Survey",
   "surveyMapFilterTitle": "Mostra sulla mappa",
   "surveyMapFilterTooltip": "Filtra marcatori",
+  "surveyMapFullscreen": "Mappa a schermo intero",
+  "surveyMapRecenter": "Centra sulla posizione attuale",
   "surveyMapFilterChipAll": "Tutte le rilevazioni",
   "surveyMapFilterAll": "Tutte le rilevazioni",
   "surveyMapFilterWithAudio": "Con clip audio",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -727,6 +727,8 @@
   "surveyTrackMap": "Survey Volgen",
   "surveyMapFilterTitle": "Toon op kaart",
   "surveyMapFilterTooltip": "Kaartmarkeringen filteren",
+  "surveyMapFullscreen": "Kaart op volledig scherm",
+  "surveyMapRecenter": "Centreren op je huidige positie",
   "surveyMapFilterChipAll": "Alle detecties",
   "surveyMapFilterAll": "Alle detecties",
   "surveyMapFilterWithAudio": "Met audioclip",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -727,6 +727,8 @@
   "surveyTrackMap": "Survey Utwór",
   "surveyMapFilterTitle": "Pokaż na mapie",
   "surveyMapFilterTooltip": "Filtruj znaczniki mapy",
+  "surveyMapFullscreen": "Mapa na pełnym ekranie",
+  "surveyMapRecenter": "Wyśrodkuj na bieżącej pozycji",
   "surveyMapFilterChipAll": "Wszystkie wykrycia",
   "surveyMapFilterAll": "Wszystkie wykrycia",
   "surveyMapFilterWithAudio": "Z klipem dźwiękowym",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -713,6 +713,8 @@
   "surveyTrackMap": "Percurso do Survey",
   "surveyMapFilterTitle": "Mostrar no mapa",
   "surveyMapFilterTooltip": "Filtrar marcadores",
+  "surveyMapFullscreen": "Mapa em tela cheia",
+  "surveyMapRecenter": "Centralizar na posição atual",
   "surveyMapFilterChipAll": "Todas as detecções",
   "surveyMapFilterAll": "Todas as deteções",
   "surveyMapFilterWithAudio": "Com clipe de áudio",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -727,6 +727,8 @@
   "surveyTrackMap": "Survey Трек",
   "surveyMapFilterTitle": "Показать на карте",
   "surveyMapFilterTooltip": "Фильтровать маркеры карты",
+  "surveyMapFullscreen": "Карта на весь экран",
+  "surveyMapRecenter": "Центрировать по текущей позиции",
   "surveyMapFilterChipAll": "Все обнаружения",
   "surveyMapFilterAll": "Все обнаружения",
   "surveyMapFilterWithAudio": "С аудиоклипом",

--- a/test/features/survey/widgets/survey_map_marker_size_test.dart
+++ b/test/features/survey/widgets/survey_map_marker_size_test.dart
@@ -1,0 +1,146 @@
+// =============================================================================
+// Survey Map Marker Sizing Tests
+// =============================================================================
+//
+// flutter_map hands each marker's child *tight* constraints. A bare sized
+// Container inflates to fill those, which silently blew silent (no-clip)
+// markers up to the full marker box — bigger than the audio markers they are
+// meant to sit behind. These tests pin the intended sizing.
+// =============================================================================
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:birdnet_live/core/constants/app_constants.dart';
+import 'package:birdnet_live/features/explore/explore_providers.dart';
+import 'package:birdnet_live/features/live/live_session.dart';
+import 'package:birdnet_live/features/survey/widgets/survey_map_widget.dart';
+import 'package:birdnet_live/l10n/app_localizations.dart';
+import 'package:birdnet_live/shared/providers/app_providers.dart';
+import 'package:birdnet_live/shared/services/taxonomy_service.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  late SharedPreferences prefs;
+  late Directory tempDir;
+  late String clipPath;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({PrefKeys.privacyAllowMap: true});
+    prefs = await SharedPreferences.getInstance();
+    tempDir = await Directory.systemTemp.createTemp('survey_map_marker_test');
+    clipPath = '${tempDir.path}/clip.wav';
+    await File(clipPath).writeAsBytes(const [0, 1, 2, 3]);
+  });
+
+  tearDown(() async {
+    if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+  });
+
+  DetectionRecord record({
+    required String scientificName,
+    required double latitude,
+    String? audioClipPath,
+  }) {
+    return DetectionRecord(
+      scientificName: scientificName,
+      commonName: scientificName,
+      confidence: 0.8,
+      timestamp: DateTime(2026, 7, 5, 10),
+      latitude: latitude,
+      longitude: 13.405,
+      audioClipPath: audioClipPath,
+    );
+  }
+
+  Widget buildSubject(List<DetectionRecord> detections) {
+    return ProviderScope(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        // Keep the taxonomy pending: markers fall back to the placeholder
+        // image, which is all these layout assertions need.
+        taxonomyServiceProvider.overrideWith(
+          (ref) => Completer<TaxonomyService>().future,
+        ),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: SurveyMapWidget(
+            gpsTrack: const [],
+            detections: detections,
+            initialCenter: const LatLng(52.52, 13.405),
+            onMarkerTap: (_) {},
+            tileLayerBuilder: (_) => const SizedBox.shrink(),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Rendered diameter of the avatar behind [label]'s marker. The avatar's
+  /// ClipOval is the photo circle itself, so this is what the eye reads as
+  /// "how big is this pin".
+  Size avatarSize(WidgetTester tester, String label) {
+    return tester.getSize(
+      find
+          .descendant(
+            of: find.bySemanticsLabel(label),
+            matching: find.byType(ClipOval),
+          )
+          .first,
+    );
+  }
+
+  testWidgets('a silent marker is not inflated to the marker box size', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      buildSubject([record(scientificName: 'Parus major', latitude: 52.52)]),
+    );
+    await tester.pump();
+
+    final semantics = tester.ensureSemantics();
+    try {
+      // The 48 px marker box would render a ~44 px circle once borders are
+      // subtracted; the intended silent avatar is far smaller than that.
+      final size = avatarSize(tester, 'Parus major');
+      expect(size.width, lessThan(40));
+      expect(size.width, size.height);
+    } finally {
+      semantics.dispose();
+    }
+  });
+
+  testWidgets('silent and audio markers read as the same size', (tester) async {
+    await tester.pumpWidget(
+      buildSubject([
+        record(scientificName: 'Parus major', latitude: 52.52),
+        record(
+          scientificName: 'Turdus merula',
+          latitude: 52.5201,
+          audioClipPath: clipPath,
+        ),
+      ]),
+    );
+    await tester.pump();
+
+    final semantics = tester.ensureSemantics();
+    try {
+      final silent = avatarSize(tester, 'Parus major').width;
+      final audio = avatarSize(tester, 'Turdus merula').width;
+      // The audio marker carries a play badge that overhangs its avatar, so
+      // its circle is allowed to be a little smaller — never the other way
+      // round, and never by more than a few pixels.
+      expect(silent, lessThan(audio));
+      expect(audio - silent, lessThanOrEqualTo(6));
+    } finally {
+      semantics.dispose();
+    }
+  });
+}


### PR DESCRIPTION
Introduce a full screen mode for the survey map, allowing users to pan and zoom without interruptions from GPS updates. Include a recenter button for convenience. Fix marker sizing issues to ensure consistent visual representation of detections with and without audio clips.