### PR TITLE
chore(android): upgrade to AGP 9, enable optimized resource shrinking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded the Android build toolchain to AGP 9.0.1, Gradle 9.1.0, and Kotlin 2.3.20, which enables R8 optimized resource shrinking and trims the app bundle slightly. Needs on-device testing before release.
+
 ## [1.0.3] - 2026-08-01
 
 ### Fixed

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,6 +1,22 @@
 org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryError
+
+# ── Build performance ─────────────────────────────────────────────
+# The build has 23 Gradle projects (app + models_pack + 21 Flutter plugin
+# modules). Without these it configures and executes them one at a time,
+# which leaves most cores idle on any modern machine.
+org.gradle.parallel=true
+org.gradle.caching=true
+
 android.useAndroidX=true
 android.enableJetifier=false
+# Must stay false on Windows. Kotlin's incremental caches are memory-mapped
+# .tab files; with 21 plugin modules compiling at once the build dies with
+# "Could not close incremental caches in ...\caches-jvm\jvm\kotlin". Verified
+# by flipping it to true — every Kotlin module failed. Costs a full Kotlin
+# recompile per build, which is small next to the asset/packaging phases.
 kotlin.incremental=false
 android.newDsl=false
 android.builtInKotlin=false
+# R8 optimized resource shrinking. Only recognized by AGP 9+; addresses the
+# Play Console recommendation. See docs/developer/play-console-recommendations.md
+android.r8.optimizedResourceShrinking=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -22,9 +22,9 @@ plugins {
     // segment alignment by default, which is required for Google Play's
     // 16 KB memory-page-size compatibility check (Android 15+ devices).
     // See: https://developer.android.com/guide/practices/page-sizes
-    id "com.android.application" version "8.11.1" apply false
-    id "com.android.asset-pack" version "8.11.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
+    id "com.android.application" version "9.0.1" apply false
+    id "com.android.asset-pack" version "9.0.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.3.20" apply false
 }
 
 include ":app"

--- a/docs/developer/build-performance.md
+++ b/docs/developer/build-performance.md
@@ -1,0 +1,150 @@
+# Build Performance (Windows)
+
+Android release builds of this app are slow on Windows in a way they are not on
+macOS. This page records what was measured, what was changed, and what is left
+on the table.
+
+## What the build actually moves
+
+Measured on this repo after a release build:
+
+| Path | Files | Size |
+| ---- | ----- | ---- |
+| `build/` | 111,043 | 7.35 GB |
+| `.dart_tool/` | 749 | 3.10 GB |
+| `assets/` | 9,836 | 235 MB |
+| `android/models_pack/` | 5 | 76.9 MB |
+
+The shape matters more than the totals. This is a *many-small-files* workload —
+over a hundred thousand file creations per build — and that is precisely the
+workload where Windows is worst relative to macOS:
+
+- **Every file write passes through Defender's real-time filter driver.**
+  Real-time protection is enabled on this machine (confirmed via
+  `Get-MpComputerStatus`). APFS on macOS has no equivalent per-write scan.
+- **NTFS metadata operations** (create/open/close/delete) are substantially more
+  expensive than APFS equivalents, and this build does an enormous number of them.
+- The app is unusually asset-heavy — ~259 MB of ONNX models stored `noCompress`
+  so they can be memory-mapped — so large files get copied and packaged
+  repeatedly on top of the small-file churn.
+
+## Measured results
+
+`flutter build appbundle --release`, same machine (14 cores), timing taken from
+Gradle's own `bundleRelease` figure:
+
+| Config | Defender | `bundleRelease` | AAB |
+| ------ | -------- | --------------- | --- |
+| AGP 8.11.1, no perf flags | scanning | **761.7 s** | 230.7 MB |
+| AGP 8.11.1, no perf flags | excluded | **466.6 s** | 230.7 MB |
+| AGP 9.0.1 + parallel + caching | excluded | **315.3 s** | 229.5 MB |
+
+**761.7 s → 315.3 s overall, a 2.4× speedup.**
+
+The two changes were isolated deliberately: the middle row reverts the toolchain
+and flags to exactly the baseline, so **Defender exclusions alone account for
+−39%**. Adding AGP 9 + parallel + caching took another −32% off what remained.
+
+Read these with three caveats:
+
+- The 761.7 s baseline ran *without* `flutter clean`; both later rows include a
+  clean. The later numbers therefore did strictly more work, so the improvement
+  is understated rather than flattered.
+- `org.gradle.caching=true` writes to `~/.gradle/caches/build-cache-1`, which
+  `flutter clean` does **not** delete. The 315.3 s row benefits from cache
+  entries populated by earlier AGP 9 builds. That is representative of everyday
+  repeat builds, but a first-ever build on a fresh machine will be slower.
+- `flutter clean` itself went 75 s → 14 s across the two runs, but those deleted
+  different amounts (an accumulated multi-build tree vs. a single build's
+  output), so that pair is not a like-for-like comparison.
+
+## Changes made
+
+In `android/gradle.properties`:
+
+```properties
+org.gradle.parallel=true
+org.gradle.caching=true
+```
+
+The build has **23 Gradle projects** (`app` + `models_pack` + 21 Flutter plugin
+modules). Without `org.gradle.parallel` they are configured and executed one at
+a time, which leaves most cores idle — this machine has 14.
+
+Both were verified with a green `flutter build appbundle --release`.
+
+## What NOT to change
+
+### `kotlin.incremental` must stay `false`
+
+It looks like an easy win — it is Kotlin's own default, and it was switched off
+in a commit whose message is about app icons, so it reads as accidental. It is
+not. Flipping it to `true` fails the build on Windows:
+
+```
+Execution failed for task ':record_android:compileReleaseKotlin'.
+> java.lang.Exception: Could not close incremental caches in
+  ...\build\record_android\kotlin\compileReleaseKotlin\cacheable\caches-jvm\jvm\kotlin:
+  class-fq-name-to-source.tab, source-to-classes.tab, internal-name-to-source.tab
+```
+
+Every Kotlin module failed the same way. Kotlin's incremental caches are
+memory-mapped `.tab` files, and with 21 plugin modules compiling concurrently
+Windows cannot release the handles. This is the same file-locking pressure that
+makes the build slow in the first place.
+
+If you hit these errors after experimenting, clear the poisoned caches:
+
+```sh
+find build -type d -name caches-jvm -prune -exec rm -rf {} +
+```
+
+## Defender exclusions — the single biggest lever (applied)
+
+Worth more than every Gradle flag combined: **−39% on its own**, with nothing
+else changed. Requires an elevated PowerShell; the exclusion list cannot even be
+*read* without admin.
+
+Currently excluded on this machine:
+
+```
+C:\Users\kahst\.gradle
+C:\Users\kahst\AppData\Local\Android\Sdk
+C:\Users\kahst\AppData\Local\Google\AndroidStudio2024.3
+C:\Users\kahst\AppData\Local\Pub\Cache
+D:\Code\birdnet-live-app
+D:\flutter\flutter
+```
+
+To reproduce on another machine:
+
+```powershell
+# Run as Administrator
+Add-MpPreference -ExclusionPath 'D:\Code\birdnet-live-app'
+Add-MpPreference -ExclusionPath "$env:USERPROFILE\.gradle"
+Add-MpPreference -ExclusionPath "$env:LOCALAPPDATA\Pub\Cache"
+Add-MpPreference -ExclusionPath "$env:LOCALAPPDATA\Android\Sdk"
+Add-MpPreference -ExclusionPath 'D:\flutter\flutter'
+```
+
+`build/` and `.dart_tool/` need no separate entries — they sit under the project
+path. The easy ones to forget are `~\.gradle` and the Flutter SDK itself.
+
+Verify with `Get-MpPreference` in an elevated shell, then time a build:
+
+```sh
+flutter clean && flutter build appbundle --release
+```
+
+Note the security trade-off: these paths stop being scanned in real time. That
+is a normal developer-machine trade, but it is a decision, not a free win.
+
+## Other options, not taken
+
+- **`org.gradle.configuration-cache=true`** — potentially a large win on the
+  configuration phase given 23 projects, but Flutter's Gradle plugin has a
+  history of incompatibility with it. Untested here; try it in isolation.
+- **Raising `-Xmx4G`** — plausible on a machine with headroom, but there was no
+  evidence of heap pressure, so it would be a guess.
+- **Moving the repo/caches to a different volume** — only worth investigating if
+  `D:` turns out to be slower than `C:`; not measured.

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -52,6 +52,7 @@ See the [Developer Getting Started](getting-started.md) guide for environment se
 - [Audio Pipeline](audio-pipeline.md) — Capture, ring buffer, and processing
 - [Inference Engine](inference-engine.md) — ONNX model loading and classification
 - [ONNX Runtime Pin](onnxruntime-pin.md) — why `flutter_onnxruntime` is pinned, and when to re-check
+- [Play Console Recommendations](play-console-recommendations.md) — already-investigated Play warnings and their verdicts
 - [Spectrogram](spectrogram.md) — FFT processing and rendering
 - [Session Review](session-review.md) — Post-session editing, playback, and export
 - [Localization](localization.md) — ARB files, adding strings, translation conventions
@@ -60,4 +61,5 @@ See the [Developer Getting Started](getting-started.md) guide for environment se
 - [Code Style](code-style.md) — Conventions and standards
 - [Species Bundle](species-bundle.md) — Rebuild bundled species images and metadata
 - [Building](building.md) — Build commands and release notes
+- [Build Performance](build-performance.md) — why Windows builds are slow, what helped, what not to touch
 - [Releasing](releasing.md) — Version bumping and release process

--- a/docs/developer/play-console-recommendations.md
+++ b/docs/developer/play-console-recommendations.md
@@ -1,0 +1,139 @@
+# Play Console Recommendations
+
+Google Play's console raises automated "recommendations" against the uploaded
+bundle. They are produced by static analysis of the *shipped bytecode*, so they
+fire on code paths that exist in a dependency even when the app can never reach
+them. This page records the ones we have already investigated, so nobody has to
+work through the same deobfuscation twice.
+
+Raw recommendation text is archived alongside the crash reports in
+`dev/crashes/<version>/recommendations.txt`.
+
+## Bitmap downsampling — `BitmapFactory` without `BitmapFactory.Options` (v1.0.2)
+
+> Your app uses BitmapFactory without downsampling at: `f3.j.b`
+
+**Status: not actionable. Unreachable in this app.**
+
+Deobfuscated against `release/V1.0.2/mapping.txt`:
+
+```
+com.mr.flutter.plugin.filepicker.FileUtils -> f3.j
+    android.net.Uri compressImage(android.net.Uri, int, android.content.Context) -> b
+```
+
+So the finding is `FileUtils.compressImage()` in the **file_picker** plugin, not
+our code. In the plugin it is guarded:
+
+```kotlin
+private fun processUri(activity: Activity, uri: Uri, compressionQuality: Int): Uri {
+    return if (compressionQuality > 0 && isImage(activity.applicationContext, uri)) {
+        compressImage(uri, compressionQuality, activity.applicationContext)
+    } else {
+        uri
+    }
+}
+```
+
+`compressionQuality` defaults to `0` in file_picker's Dart API, and both of our
+call sites leave it at the default while restricting the picker to non-image
+types:
+
+- `lib/features/file_analysis/file_analysis_screen.dart` — audio extensions
+- `lib/features/survey/survey_setup_screen.dart` — `txt` / `csv`
+
+Both conditions therefore fail and `compressImage` never runs. R8 keeps the
+method because it is reachable from the plugin's method-channel dispatch, which
+is why the analyzer still sees it.
+
+**If this ever changes:** the moment we pass a non-zero `compressionQuality` or
+allow image types through the picker, this stops being theoretical and the fix
+belongs upstream in file_picker (it should set `BitmapFactory.Options.inSampleSize`).
+
+## R8 — optimized resource shrinking (v1.0.2)
+
+> Optimized resource shrinking is not enabled. Update your Android Gradle Plugin
+> to version 9.0 or higher.
+
+**Status: fixed (AGP 9 upgrade), pending device testing.**
+
+The recommendation is correct and cannot be worked around by adding a flag. The
+property that controls it is `android.r8.optimizedResourceShrinking`, and it
+exists only in AGP 9.x. Verified by scanning the plugin jars directly:
+
+| Property | AGP 8.11.1 | AGP 9.0.1 |
+| -------- | ---------- | --------- |
+| `android.r8.optimizedShrinking` | yes | yes |
+| `android.r8.integratedResourceShrinking` | yes | yes |
+| `android.r8.optimizedResourceShrinking` | **no** | **yes** |
+
+The app already sets `minifyEnabled true` and `shrinkResources true`; this is a
+further R8 mode, not a missing basic setting.
+
+### What the upgrade involved
+
+AGP 9 pulls two other tools with it. These are the versions now in the repo:
+
+| Tool | Was | Now |
+| ---- | --- | --- |
+| Android Gradle Plugin | 8.11.1 | 9.0.1 |
+| Gradle | 8.14 | 9.1.0 |
+| Kotlin Gradle Plugin | 2.2.20 | 2.3.20 |
+
+Gradle **9.1.0** is the floor, not 9.0.0 — AGP 9.0.1 rejects 9.0.0 outright:
+
+```
+Failed to apply plugin 'com.android.internal.version-check'.
+> Minimum supported Gradle version is 9.1.0. Current version is 9.0.0.
+```
+
+Result: `flutter build appbundle --release` succeeds, and the bundle went from
+**230.7 MB to 229.5 MB**, which is the optimized resource shrinking doing its
+job (the bulk of the bundle is ONNX models, which are `noCompress`, so a 1.2 MB
+drop comes entirely out of the much smaller resource section).
+
+Notes on our specific configuration:
+
+- **Proguard file is already correct.** AGP 9 rejects
+  `getDefaultProguardFile('proguard-android.txt')` because it implies
+  `-dontoptimize`. We already use `proguard-android-optimize.txt`, which is the
+  replacement AGP 9 asks for.
+- **`android.newDsl=false`** in `android/gradle.properties` opts out of the new
+  DSL, which becomes the default in AGP 9 and is the only option in AGP 10. It
+  is still honoured in 9.x, so it does not block the upgrade, but it is
+  borrowed time.
+- **`com.android.asset-pack`** must move in lockstep with AGP — we build a
+  `models_pack` asset pack.
+- Flutter 3.44 supports AGP up to 9.1 and its own project template already
+  defaults to AGP 9.0.1 + Gradle 9.1.0, so this is a well-trodden path rather
+  than bleeding edge.
+
+### Still outstanding: Built-in Kotlin
+
+The upgrade surfaced a separate warning that is *not* fixed:
+
+```
+WARNING: Your app uses the following plugins that apply Kotlin Gradle Plugin (KGP):
+dynamic_color, flutter_foreground_task, flutter_onnxruntime, flutter_tts
+Future versions of Flutter will fail to build if your app uses plugins that apply KGP.
+```
+
+`android.builtInKotlin=false` is therefore load-bearing: we cannot migrate to
+Built-in Kotlin until those four plugins stop applying KGP themselves. One of
+them, `flutter_onnxruntime`, is deliberately pinned to an old version (see
+[ONNX Runtime Pin](onnxruntime-pin.md)), so that plugin is blocked on two fronts
+at once. This is a "watch the plugin changelogs" item, not something we can fix
+locally.
+
+### Ship it separately from a crash hotfix
+
+The build is green, but a toolchain bump changes how every class is compiled and
+shrunk, and optimized resource shrinking *rewrites resources* — breakage there
+shows up at runtime, not at build time. A successful `bundleRelease` is not
+evidence the app still works.
+
+Do not fold this into a hotfix release. Land it on its own, and smoke-test on
+real devices across a couple of Android versions first — with attention to
+anything resource-driven (icons, notification channels, widget layouts, the
+Quick Listen home-screen widget). Bundling an unvalidated toolchain change into
+a crash fix is exactly the failure mode that produced the v1.0.2 crash.


### PR DESCRIPTION
Play Console flags that optimized resource shrinking is off. The property that controls it, android.r8.optimizedResourceShrinking, exists only in AGP 9+ -- verified by scanning the plugin jars, where 8.11.1 has optimizedShrinking and integratedResourceShrinking but not the resource variant. There is no way to enable it on 8.x, so the recommendation genuinely requires the upgrade.

- AGP 8.11.1 -> 9.0.1, Gradle 8.14 -> 9.1.0, KGP 2.2.20 -> 2.3.20. Gradle 9.1.0 is a hard floor; AGP 9.0.1 rejects 9.0.0 outright.
- Enable android.r8.optimizedResourceShrinking. The bundle drops 230.7 -> 229.5 MB, which all comes out of the resource section since the ONNX models are noCompress.
- Add org.gradle.parallel and org.gradle.caching. The build has 23 Gradle projects (app + models_pack + 21 plugin modules) that were configured and executed serially.

Release bundleRelease time went 761.7s -> 315.3s, though most of that is Defender exclusions applied outside the repo rather than these flags; the measurements and their caveats are in docs/developer/build-performance.md.

kotlin.incremental deliberately stays false and is now commented to say why: flipping it to true fails every Kotlin module on Windows because the memory-mapped incremental caches cannot be closed with 21 modules compiling at once.

Not folded into the 1.0.3 hotfix on purpose. A green bundleRelease is not evidence the app still runs, and optimized resource shrinking rewrites resources, so breakage surfaces at runtime -- this needs device testing on resource-driven surfaces (icons, notification channels, the Quick Listen widget) before it ships.