### PR TITLE
Add detection review status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.1] - 2026-08-10
 
+### Changed
+
+- Exports no longer report an unreviewed detection as if a reviewer had judged its identification wrong. The `Confirmed` (true/false) column in CSV and Raven exports is replaced by `Review Status`, carrying `confirmed`, `rejected` or `unreviewed`, and `Confirmed At (UTC)` becomes `Reviewed At (UTC)`. JSON detections swap the `confirmed` boolean for a `reviewStatus` string plus `reviewedAt`. Scripts that read the old column or key need updating.
+
 ### Added
 
 - New **Adaptive location filter** mode, alongside the existing Location filter and Location weighting. It asks for more confidence the less common a species is at your location, using the same abundance tiers as the Explore screen: abundant species are never filtered, while uncommon or unlisted ones need a high detection score before they show up. Detections that survive keep their original score, unlike Location weighting.

--- a/lib/features/aru/aru_controller.dart
+++ b/lib/features/aru/aru_controller.dart
@@ -412,7 +412,17 @@ class AruController {
       source: record.source,
       latitude: record.latitude ?? existing?.latitude,
       longitude: record.longitude ?? existing?.longitude,
-      confirmedAt: existing?.confirmedAt ?? record.confirmedAt,
+      // A reviewer decision on the record already in the session wins over
+      // whatever the incoming record carries; fall back to the incoming one
+      // only when the existing record is still unreviewed.
+      reviewStatus:
+          (existing != null && existing.isReviewed)
+              ? existing.reviewStatus
+              : record.reviewStatus,
+      reviewedAt:
+          (existing != null && existing.isReviewed)
+              ? existing.reviewedAt
+              : record.reviewedAt,
       note: existing?.note ?? record.note,
       voiceMemoPath: existing?.voiceMemoPath ?? record.voiceMemoPath,
     );
@@ -447,7 +457,8 @@ class AruController {
         a.clipTimestamp == b.clipTimestamp &&
         a.latitude == b.latitude &&
         a.longitude == b.longitude &&
-        a.confirmedAt == b.confirmedAt &&
+        a.reviewStatus == b.reviewStatus &&
+        a.reviewedAt == b.reviewedAt &&
         a.note == b.note &&
         a.voiceMemoPath == b.voiceMemoPath;
   }

--- a/lib/features/history/html_report.dart
+++ b/lib/features/history/html_report.dart
@@ -582,6 +582,21 @@ section.card h2 {
   background: var(--primary-dim);
   color: var(--primary);
 }
+/* Rejected pill. Same shape as .occ-confirmed but tinted with the low-score
+   red so a reviewer's "this ID is wrong" reads as the opposite verdict at a
+   glance. Unreviewed occurrences get no pill at all — silence is the honest
+   encoding for a detection nobody has judged. */
+.occ-rejected {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  background: #cf222e22;
+  color: var(--score-low);
+}
 /* Heard / seen pill on manually-entered occurrences. Neutral surface
    rather than the primary tint used by .occ-confirmed, so provenance
    reads as secondary to the confirm state. */
@@ -1414,6 +1429,8 @@ String _buildDetectionsHtml(
       }
       if (d.isConfirmed) {
         buf.writeln('          <span class="occ-confirmed">Confirmed</span>');
+      } else if (d.isRejected) {
+        buf.writeln('          <span class="occ-rejected">Rejected</span>');
       }
       buf.writeln('        </div>');
       if (hasNote) {

--- a/lib/features/history/services/detection_sharing_service.dart
+++ b/lib/features/history/services/detection_sharing_service.dart
@@ -249,7 +249,8 @@ DetectionRecord _copyDetection(
   evidence: source.evidence,
   latitude: source.latitude,
   longitude: source.longitude,
-  confirmedAt: source.confirmedAt,
+  reviewStatus: source.reviewStatus,
+  reviewedAt: source.reviewedAt,
   note: source.note,
   voiceMemoPath: source.voiceMemoPath,
 );
@@ -738,6 +739,8 @@ String _buildBody(DetectionRecord d) {
   }
   if (d.isConfirmed) {
     lines.add('Confirmed');
+  } else if (d.isRejected) {
+    lines.add('Rejected');
   }
   return lines.join('\n');
 }

--- a/lib/features/history/session_export.dart
+++ b/lib/features/history/session_export.dart
@@ -258,9 +258,9 @@ String buildRavenSelectionTable(
   // detections back to the survey timeline. We always emit it: when no clips
   // are involved it duplicates Begin Time, but having a stable column name
   // makes downstream tooling simpler than conditionally including it.
-  // 'Confirmed' / 'Confirmed At (UTC)' are likewise always emitted so the
-  // schema is stable regardless of whether the session has any confirmed
-  // detections; unconfirmed rows carry an empty 'Confirmed At'.
+  // 'Review Status' / 'Reviewed At (UTC)' are likewise always emitted so the
+  // schema is stable regardless of whether the session has any reviewed
+  // detections; unreviewed rows carry an empty 'Reviewed At'.
   final surveyTimeHeader =
       useAbsoluteSurveyTime ? 'Survey Time (UTC)' : 'Survey Time (s)';
   buf.writeln(
@@ -269,7 +269,7 @@ String buildRavenSelectionTable(
     'Low Freq (Hz)\tHigh Freq (Hz)\t'
     'Common Name\tScientific Name\tConfidence'
     '\t$surveyTimeHeader'
-    '\tConfirmed\tConfirmed At (UTC)'
+    '\tReview Status\tReviewed At (UTC)'
     '${hasCoords ? '\tLatitude\tLongitude' : ''}'
     '${hasEvidence ? '\tEvidence' : ''}'
     '${hasNotes ? '\tNote' : ''}',
@@ -329,9 +329,9 @@ String buildRavenSelectionTable(
             ? d.timestamp.toUtc().toIso8601String()
             : surveySec.toStringAsFixed(3);
     final surveyTimeSuffix = '\t$surveyTimeValue';
-    final confirmedSuffix =
-        '\t${d.isConfirmed ? 'true' : 'false'}'
-        '\t${d.confirmedAt?.toUtc().toIso8601String() ?? ''}';
+    final reviewSuffix =
+        '\t${d.reviewStatus.name}'
+        '\t${d.reviewedAt?.toUtc().toIso8601String() ?? ''}';
     final coordSuffix =
         hasCoords
             ? '\t${d.latitude?.toStringAsFixed(6) ?? ''}'
@@ -360,7 +360,7 @@ String buildRavenSelectionTable(
       '${_displaySci(d, taxonomy: taxonomy)}\t'
       '${d.confidence.toStringAsFixed(4)}'
       '$surveyTimeSuffix'
-      '$confirmedSuffix'
+      '$reviewSuffix'
       '$coordSuffix'
       '$evidenceSuffix'
       '$noteSuffix',
@@ -407,9 +407,9 @@ String buildCsvExport(
   // Survey Time is always included (see [buildRavenSelectionTable] for the
   // rationale). When [useAbsoluteSurveyTime] is true the column becomes
   // 'Survey Time (UTC)' and carries an ISO-8601 wall-clock timestamp.
-  // 'Confirmed' / 'Confirmed At (UTC)' are always emitted so downstream
-  // pipelines see a stable schema; unconfirmed rows carry an empty
-  // 'Confirmed At'.
+  // 'Review Status' / 'Reviewed At (UTC)' are always emitted so downstream
+  // pipelines see a stable schema; unreviewed rows carry an empty
+  // 'Reviewed At'.
   final surveyTimeHeader =
       useAbsoluteSurveyTime ? 'Survey Time (UTC)' : 'Survey Time (s)';
   buf.writeln(
@@ -417,7 +417,7 @@ String buildCsvExport(
     'Common Name,Scientific Name,Confidence'
     '${hasFileRefs ? ',File' : ''}'
     ',$surveyTimeHeader'
-    ',Confirmed,Confirmed At (UTC)'
+    ',Review Status,Reviewed At (UTC)'
     '${hasCoords ? ',Latitude,Longitude' : ''}'
     '${hasEvidence ? ',Evidence' : ''}'
     '${hasNotes ? ',Note' : ''}'
@@ -478,9 +478,9 @@ String buildCsvExport(
             ? d.timestamp.toUtc().toIso8601String()
             : surveySec.toStringAsFixed(3);
     final surveyTimeRef = ',$surveyTimeValue';
-    final confirmedRef =
-        ',${d.isConfirmed ? 'true' : 'false'}'
-        ',${d.confirmedAt?.toUtc().toIso8601String() ?? ''}';
+    final reviewRef =
+        ',${d.reviewStatus.name}'
+        ',${d.reviewedAt?.toUtc().toIso8601String() ?? ''}';
     final coordRef =
         hasCoords
             ? ',${d.latitude?.toStringAsFixed(6) ?? ''}'
@@ -502,7 +502,7 @@ String buildCsvExport(
       '${d.confidence.toStringAsFixed(4)}'
       '$fileRef'
       '$surveyTimeRef'
-      '$confirmedRef'
+      '$reviewRef'
       '$coordRef'
       '$evidenceRef'
       '$noteRef'
@@ -837,9 +837,12 @@ String buildJsonExport(
             if (d.longitude != null) 'longitude': d.longitude,
             if (d.source != DetectionSource.auto) 'source': d.source.name,
             if (d.evidence != null) 'evidence': d.evidence!.name,
-            'confirmed': d.isConfirmed,
-            if (d.confirmedAt != null)
-              'confirmedAt': d.confirmedAt!.toUtc().toIso8601String(),
+            // Always emitted so the schema is stable, and three-valued so an
+            // untouched detection reads as 'unreviewed' rather than claiming
+            // a reviewer judged the identification wrong.
+            'reviewStatus': d.reviewStatus.name,
+            if (d.reviewedAt != null)
+              'reviewedAt': d.reviewedAt!.toUtc().toIso8601String(),
             if (d.hasNote) 'note': d.note,
             if (d.hasVoiceMemo)
               'voiceMemo': 'memos/${p.basename(d.voiceMemoPath!)}',
@@ -1526,16 +1529,21 @@ String buildGpxExport(
     buf.writeln(
       '    <desc>${_xmlEscape(_displaySci(d, taxonomy: taxonomy))} (${(d.confidence * 100).toStringAsFixed(1)}%)</desc>',
     );
-    if (d.isConfirmed) {
+    if (d.isReviewed) {
       // GPX <sym> is a free-form symbol hint; downstream tools (QGIS,
       // GPSBabel, Garmin BaseCamp) treat unknown values as a tag rather
-      // than failing to load the waypoint, so 'confirmed' here doubles as
-      // a filterable attribute. The <cmt> note carries the confirmation
-      // timestamp so the audit trail survives the export.
-      buf.writeln('    <sym>confirmed</sym>');
-      buf.writeln(
-        '    <cmt>Confirmed at ${d.confirmedAt!.toUtc().toIso8601String()}</cmt>',
-      );
+      // than failing to load the waypoint, so the status here doubles as
+      // a filterable attribute. The <cmt> note carries the review
+      // timestamp so the audit trail survives the export. Unreviewed
+      // waypoints get neither tag — absence is the honest encoding of
+      // "nobody has judged this".
+      final verb = d.isConfirmed ? 'Confirmed' : 'Rejected';
+      buf.writeln('    <sym>${d.reviewStatus.name}</sym>');
+      if (d.reviewedAt != null) {
+        buf.writeln(
+          '    <cmt>$verb at ${d.reviewedAt!.toUtc().toIso8601String()}</cmt>',
+        );
+      }
     }
     buf.writeln('  </wpt>');
   }

--- a/lib/features/history/session_review_screen.dart
+++ b/lib/features/history/session_review_screen.dart
@@ -2672,7 +2672,8 @@ class _SessionReviewScreenState extends ConsumerState<SessionReviewScreen> {
                         ? DetectionSource.userSpecified
                         : DetectionSource.manual,
                 evidence: result.evidence,
-                confirmedAt: result.replaceRecord!.confirmedAt,
+                reviewStatus: result.replaceRecord!.reviewStatus,
+                reviewedAt: result.replaceRecord!.reviewedAt,
                 note: result.replaceRecord!.note,
                 voiceMemoPath: result.replaceRecord!.voiceMemoPath,
                 latitude: result.replaceRecord!.latitude,
@@ -3055,10 +3056,14 @@ class _SessionReviewScreenState extends ConsumerState<SessionReviewScreen> {
   /// timestamp so they group cleanly in exports.
   void _toggleClusterConfirmation(_DetectionCluster cluster) {
     final anyConfirmed = cluster.records.any((r) => r.isConfirmed);
-    final stamp = anyConfirmed ? null : DateTime.now().toUtc();
+    final stamp = DateTime.now().toUtc();
     setState(() {
       for (final r in cluster.records) {
-        r.confirmedAt = stamp;
+        if (anyConfirmed) {
+          r.clearReview();
+        } else {
+          r.markConfirmed(at: stamp);
+        }
       }
       _isDirty = true;
     });
@@ -3991,7 +3996,8 @@ class _SessionReviewScreenState extends ConsumerState<SessionReviewScreen> {
                     ? DetectionSource.userSpecified
                     : DetectionSource.manual,
             evidence: result.evidence,
-            confirmedAt: result.replaceRecord!.confirmedAt,
+            reviewStatus: result.replaceRecord!.reviewStatus,
+            reviewedAt: result.replaceRecord!.reviewedAt,
             note: result.replaceRecord!.note,
             voiceMemoPath: result.replaceRecord!.voiceMemoPath,
             latitude: result.replaceRecord!.latitude,

--- a/lib/features/history/widgets/clip_player_sheet.dart
+++ b/lib/features/history/widgets/clip_player_sheet.dart
@@ -290,7 +290,11 @@ class _ClipPlayerSheetState extends ConsumerState<_ClipPlayerSheet> {
   void _toggleConfirm() {
     final det = widget.detection;
     setState(() {
-      det.confirmedAt = det.isConfirmed ? null : DateTime.now().toUtc();
+      if (det.isConfirmed) {
+        det.clearReview();
+      } else {
+        det.markConfirmed();
+      }
     });
     widget.onConfirmChanged?.call();
   }

--- a/lib/features/inference/detection_accumulator.dart
+++ b/lib/features/inference/detection_accumulator.dart
@@ -322,7 +322,8 @@ DetectionRecord copyDetectionRecord(
     evidence: existing.evidence,
     latitude: existing.latitude,
     longitude: existing.longitude,
-    confirmedAt: existing.confirmedAt,
+    reviewStatus: existing.reviewStatus,
+    reviewedAt: existing.reviewedAt,
     note: existing.note,
     voiceMemoPath: existing.voiceMemoPath,
   );

--- a/lib/features/live/live_session.dart
+++ b/lib/features/live/live_session.dart
@@ -410,6 +410,40 @@ enum DetectionEvidence {
   };
 }
 
+/// What a reviewer has decided about a detection's species identification.
+///
+/// Deliberately three-valued: "nobody has looked at this yet" is a different
+/// claim from "a reviewer looked and judged the ID wrong", and collapsing the
+/// two into a boolean makes every export assert the latter about detections
+/// that are merely untouched.
+enum ReviewStatus {
+  /// No reviewer has passed judgement. The default for every detection, and
+  /// the only honest answer for the vast majority of them.
+  unreviewed,
+
+  /// A reviewer confirmed the species identification, visually or
+  /// acoustically.
+  confirmed,
+
+  /// A reviewer judged the species identification to be wrong.
+  ///
+  /// Fully persisted and exported, but no UI currently produces it — the
+  /// review screen still toggles between [unreviewed] and [confirmed]. It
+  /// exists so the export schema does not have to change again when an
+  /// invalidate action lands.
+  rejected;
+
+  /// Parse a persisted [name], tolerating null / unknown values.
+  ///
+  /// Unknown values fall back to [unreviewed] rather than throwing, so a
+  /// session written by a future build with more states still loads.
+  static ReviewStatus fromName(String? name) => switch (name) {
+    'confirmed' => ReviewStatus.confirmed,
+    'rejected' => ReviewStatus.rejected,
+    _ => ReviewStatus.unreviewed,
+  };
+}
+
 /// A timestamped detection record for session persistence.
 ///
 /// Unlike [Detection] (which holds a full [Species] object), this stores
@@ -427,7 +461,8 @@ class DetectionRecord {
     this.evidence,
     this.latitude,
     this.longitude,
-    this.confirmedAt,
+    this.reviewStatus = ReviewStatus.unreviewed,
+    this.reviewedAt,
     this.note,
     this.voiceMemoPath,
   });
@@ -505,17 +540,54 @@ class DetectionRecord {
   /// GPS longitude at the time of detection (null if unavailable).
   final double? longitude;
 
-  /// UTC wall-clock time when a reviewer marked this detection as visually
-  /// or acoustically confirmed. `null` means the detection has not been
-  /// confirmed (the default state — confirmation is opt-in).
+  /// What a reviewer has decided about this detection's identification.
   ///
-  /// Mutable: toggled from the session-review UI. Persisted in JSON
-  /// sessions and propagated to all export formats so external pipelines
-  /// can filter on confirmed-only detections.
-  DateTime? confirmedAt;
+  /// Defaults to [ReviewStatus.unreviewed] — review is opt-in, and most
+  /// detections in a session are never touched. Consumers must not read
+  /// "not confirmed" as "judged incorrect"; only [ReviewStatus.rejected]
+  /// carries that claim.
+  ///
+  /// Mutable: set from the session-review UI via [markConfirmed],
+  /// [markRejected] and [clearReview]. Persisted in JSON sessions and
+  /// propagated to all export formats so external pipelines can filter on
+  /// review state.
+  ReviewStatus reviewStatus;
 
-  /// Convenience: whether this detection has been marked confirmed.
-  bool get isConfirmed => confirmedAt != null;
+  /// UTC wall-clock time when the reviewer made the decision recorded in
+  /// [reviewStatus]. `null` while [reviewStatus] is
+  /// [ReviewStatus.unreviewed].
+  DateTime? reviewedAt;
+
+  /// Convenience: whether a reviewer confirmed this identification.
+  bool get isConfirmed => reviewStatus == ReviewStatus.confirmed;
+
+  /// Convenience: whether a reviewer judged this identification wrong.
+  bool get isRejected => reviewStatus == ReviewStatus.rejected;
+
+  /// Convenience: whether any reviewer decision has been recorded.
+  bool get isReviewed => reviewStatus != ReviewStatus.unreviewed;
+
+  /// Record that a reviewer confirmed this identification.
+  ///
+  /// [at] defaults to now; callers pass it explicitly when stamping a whole
+  /// cluster so every record shares one timestamp.
+  void markConfirmed({DateTime? at}) {
+    reviewStatus = ReviewStatus.confirmed;
+    reviewedAt = (at ?? DateTime.now()).toUtc();
+  }
+
+  /// Record that a reviewer judged this identification wrong.
+  void markRejected({DateTime? at}) {
+    reviewStatus = ReviewStatus.rejected;
+    reviewedAt = (at ?? DateTime.now()).toUtc();
+  }
+
+  /// Drop any reviewer decision, returning the record to
+  /// [ReviewStatus.unreviewed].
+  void clearReview() {
+    reviewStatus = ReviewStatus.unreviewed;
+    reviewedAt = null;
+  }
 
   /// Free-form text note attached to this detection by the reviewer.
   ///
@@ -593,10 +665,20 @@ class DetectionRecord {
       evidence: DetectionEvidence.fromName(json['evidence'] as String?),
       latitude: (json['detLat'] as num?)?.toDouble(),
       longitude: (json['detLon'] as num?)?.toDouble(),
-      confirmedAt:
-          json['confirmedAt'] != null
-              ? DateTime.parse(json['confirmedAt'] as String)
-              : null,
+      // Sessions written before review became three-valued carry only
+      // `confirmedAt`, where a non-null value meant confirmed. Prefer the
+      // explicit status when present and fall back to that legacy shape so
+      // older sessions keep their confirmations.
+      reviewStatus:
+          json['reviewStatus'] != null
+              ? ReviewStatus.fromName(json['reviewStatus'] as String?)
+              : (json['confirmedAt'] != null
+                  ? ReviewStatus.confirmed
+                  : ReviewStatus.unreviewed),
+      reviewedAt: switch (json['reviewedAt'] ?? json['confirmedAt']) {
+        final String stamp => DateTime.parse(stamp),
+        _ => null,
+      },
       note: json['note'] as String?,
       voiceMemoPath: json['voiceMemoPath'] as String?,
     );
@@ -617,8 +699,14 @@ class DetectionRecord {
     if (evidence != null) 'evidence': evidence!.name,
     if (latitude != null) 'detLat': latitude,
     if (longitude != null) 'detLon': longitude,
-    if (confirmedAt != null)
-      'confirmedAt': confirmedAt!.toUtc().toIso8601String(),
+    if (isReviewed) 'reviewStatus': reviewStatus.name,
+    if (reviewedAt != null) 'reviewedAt': reviewedAt!.toUtc().toIso8601String(),
+    // Legacy mirror: a build older than the three-state change reads only
+    // `confirmedAt`, so keep writing it for confirmed records. Without this,
+    // rolling back to such a build silently drops every confirmation. Safe to
+    // remove a couple of releases after 1.1.1.
+    if (isConfirmed && reviewedAt != null)
+      'confirmedAt': reviewedAt!.toUtc().toIso8601String(),
     if (hasNote) 'note': note,
     if (hasVoiceMemo) 'voiceMemoPath': voiceMemoPath,
   };
@@ -1189,7 +1277,8 @@ class LiveSession {
       evidence: r.evidence,
       latitude: r.latitude,
       longitude: r.longitude,
-      confirmedAt: r.confirmedAt,
+      reviewStatus: r.reviewStatus,
+      reviewedAt: r.reviewedAt,
       note: r.note,
       voiceMemoPath: r.voiceMemoPath,
     );

--- a/lib/features/survey/survey_live_screen.dart
+++ b/lib/features/survey/survey_live_screen.dart
@@ -1071,8 +1071,11 @@ class _SurveyLiveScreenState extends ConsumerState<SurveyLiveScreen>
                 isConfirmed: detection.isConfirmed,
                 onToggleConfirm: () {
                   setState(() {
-                    detection.confirmedAt =
-                        detection.isConfirmed ? null : DateTime.now().toUtc();
+                    if (detection.isConfirmed) {
+                      detection.clearReview();
+                    } else {
+                      detection.markConfirmed();
+                    }
                   });
                 },
                 onShare:

--- a/test/features/history/html_report_test.dart
+++ b/test/features/history/html_report_test.dart
@@ -43,7 +43,8 @@ LiveSession _sessionWithDetections() {
         latitude: 50.1234,
         longitude: 8.5678,
         note: 'note with <b>tag</b> & symbols',
-        confirmedAt: DateTime.utc(2026, 5, 28, 10, 1, 30),
+        reviewStatus: ReviewStatus.confirmed,
+        reviewedAt: DateTime.utc(2026, 5, 28, 10, 1, 30),
       ),
     ],
   );
@@ -72,6 +73,26 @@ void main() {
       expect(html, contains('clip%20%231.wav'));
       expect(html, contains('Confirmed'));
       expect(html, contains('Recording settings'));
+    });
+
+    test('badges a rejected detection and leaves unreviewed ones bare', () {
+      // Match the rendered pill, not the class name — both CSS rules are in
+      // the stylesheet of every report regardless of review state.
+      const rejectedPill = '<span class="occ-rejected">Rejected</span>';
+      const confirmedPill = '<span class="occ-confirmed">Confirmed</span>';
+
+      final session = _sessionWithDetections();
+      session.detections.single.markRejected(
+        at: DateTime.utc(2026, 5, 28, 10, 1, 30),
+      );
+      final rejected = buildHtmlReport(session);
+      expect(rejected, contains(rejectedPill));
+      expect(rejected, isNot(contains(confirmedPill)));
+
+      session.detections.single.clearReview();
+      final bare = buildHtmlReport(session);
+      expect(bare, isNot(contains(rejectedPill)));
+      expect(bare, isNot(contains(confirmedPill)));
     });
 
     test('renders full recording player when audioFileName is provided', () {

--- a/test/features/history/session_export_test.dart
+++ b/test/features/history/session_export_test.dart
@@ -1571,14 +1571,15 @@ void main() {
 
   // â”€â”€ Confirmed-detection flag in exports (#33) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
-  group('confirmed-detection flag in exports', () {
-    DetectionRecord makeConfirmed(
+  group('review status in exports', () {
+    DetectionRecord makeReviewed(
       String sci,
       String common,
       double conf,
       Duration offset,
       DateTime start, {
-      DateTime? confirmedAt,
+      ReviewStatus reviewStatus = ReviewStatus.unreviewed,
+      DateTime? reviewedAt,
       double? lat,
       double? lon,
     }) {
@@ -1587,31 +1588,42 @@ void main() {
         commonName: common,
         confidence: conf,
         timestamp: start.add(offset),
-        confirmedAt: confirmedAt,
+        reviewStatus: reviewStatus,
+        reviewedAt: reviewedAt,
         latitude: lat,
         longitude: lon,
       );
     }
 
-    test('Raven table emits Confirmed columns and per-row values', () {
+    test('Raven table emits Review Status columns and per-row values', () {
       final start = DateTime.utc(2025, 6, 15, 8, 0, 0);
       final stamp = DateTime.utc(2025, 6, 15, 9, 30);
       final session = _makeSession(
         detections: [
-          makeConfirmed(
+          makeReviewed(
             'Turdus merula',
             'Eurasian Blackbird',
             0.91,
             const Duration(seconds: 5),
             start,
-            confirmedAt: stamp,
+            reviewStatus: ReviewStatus.confirmed,
+            reviewedAt: stamp,
           ),
-          makeConfirmed(
+          makeReviewed(
             'Erithacus rubecula',
             'European Robin',
             0.80,
             const Duration(seconds: 10),
             start,
+          ),
+          makeReviewed(
+            'Parus major',
+            'Great Tit',
+            0.75,
+            const Duration(seconds: 15),
+            start,
+            reviewStatus: ReviewStatus.rejected,
+            reviewedAt: stamp,
           ),
         ],
       );
@@ -1619,39 +1631,55 @@ void main() {
       final table = buildRavenSelectionTable(session);
       final lines = table.split('\n');
       final header = lines.first.split('\t');
-      expect(header, contains('Confirmed'));
-      expect(header, contains('Confirmed At (UTC)'));
-      final cIdx = header.indexOf('Confirmed');
-      final cAtIdx = header.indexOf('Confirmed At (UTC)');
+      expect(header, contains('Review Status'));
+      expect(header, contains('Reviewed At (UTC)'));
+      final cIdx = header.indexOf('Review Status');
+      final cAtIdx = header.indexOf('Reviewed At (UTC)');
 
       final row1 = lines[1].split('\t');
-      expect(row1[cIdx], 'true');
+      expect(row1[cIdx], 'confirmed');
       expect(row1[cAtIdx], '2025-06-15T09:30:00.000Z');
 
+      // The point of the whole exercise: a detection nobody reviewed says so,
+      // rather than reporting a verdict it never received.
       final row2 = lines[2].split('\t');
-      expect(row2[cIdx], 'false');
+      expect(row2[cIdx], 'unreviewed');
       expect(row2[cAtIdx], '');
+
+      final row3 = lines[3].split('\t');
+      expect(row3[cIdx], 'rejected');
+      expect(row3[cAtIdx], '2025-06-15T09:30:00.000Z');
     });
 
-    test('CSV emits Confirmed columns and per-row values', () {
+    test('CSV emits Review Status columns and per-row values', () {
       final start = DateTime.utc(2025, 6, 15, 8, 0, 0);
       final stamp = DateTime.utc(2025, 6, 15, 9, 30);
       final session = _makeSession(
         detections: [
-          makeConfirmed(
+          makeReviewed(
             'Turdus merula',
             'Eurasian Blackbird',
             0.91,
             const Duration(seconds: 5),
             start,
-            confirmedAt: stamp,
+            reviewStatus: ReviewStatus.confirmed,
+            reviewedAt: stamp,
           ),
-          makeConfirmed(
+          makeReviewed(
             'Erithacus rubecula',
             'European Robin',
             0.80,
             const Duration(seconds: 10),
             start,
+          ),
+          makeReviewed(
+            'Parus major',
+            'Great Tit',
+            0.75,
+            const Duration(seconds: 15),
+            start,
+            reviewStatus: ReviewStatus.rejected,
+            reviewedAt: stamp,
           ),
         ],
       );
@@ -1659,39 +1687,55 @@ void main() {
       final csv = buildCsvExport(session);
       final lines = csv.split('\n');
       final header = lines.first.split(',');
-      expect(header, contains('Confirmed'));
-      expect(header, contains('Confirmed At (UTC)'));
-      final cIdx = header.indexOf('Confirmed');
-      final cAtIdx = header.indexOf('Confirmed At (UTC)');
+      expect(header, contains('Review Status'));
+      expect(header, contains('Reviewed At (UTC)'));
+      final cIdx = header.indexOf('Review Status');
+      final cAtIdx = header.indexOf('Reviewed At (UTC)');
 
       final row1 = lines[1].split(',');
-      expect(row1[cIdx], 'true');
+      expect(row1[cIdx], 'confirmed');
       expect(row1[cAtIdx], '2025-06-15T09:30:00.000Z');
 
+      // The point of the whole exercise: a detection nobody reviewed says so,
+      // rather than reporting a verdict it never received.
       final row2 = lines[2].split(',');
-      expect(row2[cIdx], 'false');
+      expect(row2[cIdx], 'unreviewed');
       expect(row2[cAtIdx], '');
+
+      final row3 = lines[3].split(',');
+      expect(row3[cIdx], 'rejected');
+      expect(row3[cAtIdx], '2025-06-15T09:30:00.000Z');
     });
 
-    test('JSON emits confirmed (always) and confirmedAt (only when set)', () {
+    test('JSON emits reviewStatus (always) and reviewedAt (only when set)', () {
       final start = DateTime.utc(2025, 6, 15, 8, 0, 0);
       final stamp = DateTime.utc(2025, 6, 15, 9, 30);
       final session = _makeSession(
         detections: [
-          makeConfirmed(
+          makeReviewed(
             'Turdus merula',
             'Eurasian Blackbird',
             0.91,
             const Duration(seconds: 5),
             start,
-            confirmedAt: stamp,
+            reviewStatus: ReviewStatus.confirmed,
+            reviewedAt: stamp,
           ),
-          makeConfirmed(
+          makeReviewed(
             'Erithacus rubecula',
             'European Robin',
             0.80,
             const Duration(seconds: 10),
             start,
+          ),
+          makeReviewed(
+            'Parus major',
+            'Great Tit',
+            0.75,
+            const Duration(seconds: 15),
+            start,
+            reviewStatus: ReviewStatus.rejected,
+            reviewedAt: stamp,
           ),
         ],
       );
@@ -1700,10 +1744,16 @@ void main() {
       final dets = map['detections'] as List;
       final d0 = dets[0] as Map<String, dynamic>;
       final d1 = dets[1] as Map<String, dynamic>;
-      expect(d0['confirmed'], true);
-      expect(d0['confirmedAt'], '2025-06-15T09:30:00.000Z');
-      expect(d1['confirmed'], false);
-      expect(d1.containsKey('confirmedAt'), isFalse);
+      final d2 = dets[2] as Map<String, dynamic>;
+      expect(d0['reviewStatus'], 'confirmed');
+      expect(d0['reviewedAt'], '2025-06-15T09:30:00.000Z');
+      expect(d1['reviewStatus'], 'unreviewed');
+      expect(d1.containsKey('reviewedAt'), isFalse);
+      expect(d2['reviewStatus'], 'rejected');
+      expect(d2['reviewedAt'], '2025-06-15T09:30:00.000Z');
+      // The old boolean is gone; nothing should still be asserting a verdict
+      // about the unreviewed detection.
+      expect(d1.containsKey('confirmed'), isFalse);
     });
 
     test(
@@ -1714,17 +1764,18 @@ void main() {
         final session = _makeSession(
           type: SessionType.survey,
           detections: [
-            makeConfirmed(
+            makeReviewed(
               'Turdus merula',
               'Eurasian Blackbird',
               0.91,
               const Duration(seconds: 5),
               start,
-              confirmedAt: stamp,
+              reviewStatus: ReviewStatus.confirmed,
+              reviewedAt: stamp,
               lat: 52.52,
               lon: 13.40,
             ),
-            makeConfirmed(
+            makeReviewed(
               'Erithacus rubecula',
               'European Robin',
               0.80,
@@ -1748,6 +1799,43 @@ void main() {
         expect('<cmt>'.allMatches(gpx).length, 1);
       },
     );
+
+    test('GPX tags rejected waypoints distinctly from confirmed ones', () {
+      final start = DateTime.utc(2025, 6, 15, 8, 0, 0);
+      final stamp = DateTime.utc(2025, 6, 15, 9, 30);
+      final session = _makeSession(
+        type: SessionType.survey,
+        detections: [
+          makeReviewed(
+            'Parus major',
+            'Great Tit',
+            0.75,
+            const Duration(seconds: 15),
+            start,
+            reviewStatus: ReviewStatus.rejected,
+            reviewedAt: stamp,
+            lat: 52.54,
+            lon: 13.42,
+          ),
+          makeReviewed(
+            'Erithacus rubecula',
+            'European Robin',
+            0.80,
+            const Duration(seconds: 10),
+            start,
+            lat: 52.53,
+            lon: 13.41,
+          ),
+        ],
+      );
+
+      final gpx = buildGpxExport(session);
+      expect(gpx, contains('<sym>rejected</sym>'));
+      expect(gpx, contains('<cmt>Rejected at 2025-06-15T09:30:00.000Z</cmt>'));
+      expect(gpx, isNot(contains('<sym>confirmed</sym>')));
+      // The unreviewed waypoint stays untagged.
+      expect('<sym>'.allMatches(gpx).length, 1);
+    });
   });
 
   group('heard/seen evidence in exports', () {

--- a/test/features/inference/detection_accumulator_test.dart
+++ b/test/features/inference/detection_accumulator_test.dart
@@ -155,7 +155,7 @@ void main() {
   });
 
   test('confidence and close replacements preserve review metadata', () {
-    final confirmedAt = start.add(const Duration(seconds: 1));
+    final reviewedAt = start.add(const Duration(seconds: 1));
     final records = <DetectionRecord>[];
     final accumulator = DetectionAccumulator(
       sessionStart: start,
@@ -170,7 +170,8 @@ void main() {
             commonName: detection.species.commonName,
             confidence: detection.confidence,
             timestamp: timestamp,
-            confirmedAt: confirmedAt,
+            reviewStatus: ReviewStatus.confirmed,
+            reviewedAt: reviewedAt,
             note: 'field note',
             voiceMemoPath: '/memo.m4a',
           ),
@@ -181,7 +182,8 @@ void main() {
     );
     accumulator.closeAll();
 
-    expect(records.single.confirmedAt, confirmedAt);
+    expect(records.single.reviewStatus, ReviewStatus.confirmed);
+    expect(records.single.reviewedAt, reviewedAt);
     expect(records.single.note, 'field note');
     expect(records.single.voiceMemoPath, '/memo.m4a');
   });

--- a/test/features/live/live_session_test.dart
+++ b/test/features/live/live_session_test.dart
@@ -289,37 +289,103 @@ void main() {
       expect(json.containsKey('audioClipPath'), isFalse);
     });
 
-    test('confirmedAt defaults to null and isConfirmed is false', () {
+    test('review defaults to unreviewed with no timestamp', () {
       final record = DetectionRecord(
         scientificName: 'Turdus merula',
         commonName: 'Eurasian Blackbird',
         confidence: 0.85,
         timestamp: DateTime.now(),
       );
-      expect(record.confirmedAt, isNull);
+      expect(record.reviewStatus, ReviewStatus.unreviewed);
+      expect(record.reviewedAt, isNull);
       expect(record.isConfirmed, isFalse);
-      expect(record.toJson().containsKey('confirmedAt'), isFalse);
+      expect(record.isRejected, isFalse);
+      expect(record.isReviewed, isFalse);
+      final json = record.toJson();
+      expect(json.containsKey('reviewStatus'), isFalse);
+      expect(json.containsKey('reviewedAt'), isFalse);
+      // An unreviewed record must never claim a verdict, including via the
+      // legacy key older builds read.
+      expect(json.containsKey('confirmedAt'), isFalse);
     });
 
-    test('confirmedAt round-trips as UTC ISO string', () {
-      final confirmed = DateTime.utc(2026, 5, 6, 12, 30, 45);
+    test('confirmed review round-trips as UTC ISO string', () {
+      final stamp = DateTime.utc(2026, 5, 6, 12, 30, 45);
       final record = DetectionRecord(
         scientificName: 'Turdus merula',
         commonName: 'Eurasian Blackbird',
         confidence: 0.85,
         timestamp: DateTime(2026, 5, 6, 12, 0, 0),
-        confirmedAt: confirmed,
+        reviewStatus: ReviewStatus.confirmed,
+        reviewedAt: stamp,
       );
 
       final json = record.toJson();
-      expect(json['confirmedAt'], endsWith('Z'));
+      expect(json['reviewStatus'], 'confirmed');
+      expect(json['reviewedAt'], endsWith('Z'));
 
       final roundTripped = DetectionRecord.fromJson(json);
+      expect(roundTripped.reviewStatus, ReviewStatus.confirmed);
       expect(roundTripped.isConfirmed, isTrue);
-      expect(roundTripped.confirmedAt!.isAtSameMomentAs(confirmed), isTrue);
+      expect(roundTripped.reviewedAt!.isAtSameMomentAs(stamp), isTrue);
     });
 
-    test('legacy JSON without confirmedAt deserializes with null', () {
+    test('rejected review round-trips', () {
+      final stamp = DateTime.utc(2026, 5, 6, 12, 30, 45);
+      final record = DetectionRecord(
+        scientificName: 'Turdus merula',
+        commonName: 'Eurasian Blackbird',
+        confidence: 0.85,
+        timestamp: DateTime(2026, 5, 6, 12, 0, 0),
+        reviewStatus: ReviewStatus.rejected,
+        reviewedAt: stamp,
+      );
+
+      final json = record.toJson();
+      expect(json['reviewStatus'], 'rejected');
+      // The legacy mirror is confirmation-only: a build that predates
+      // rejection must not read a rejected record back as confirmed.
+      expect(json.containsKey('confirmedAt'), isFalse);
+
+      final roundTripped = DetectionRecord.fromJson(json);
+      expect(roundTripped.reviewStatus, ReviewStatus.rejected);
+      expect(roundTripped.isRejected, isTrue);
+      expect(roundTripped.isConfirmed, isFalse);
+      expect(roundTripped.reviewedAt!.isAtSameMomentAs(stamp), isTrue);
+    });
+
+    test('confirmed record writes the legacy confirmedAt mirror', () {
+      final stamp = DateTime.utc(2026, 5, 6, 12, 30, 45);
+      final record = DetectionRecord(
+        scientificName: 'Turdus merula',
+        commonName: 'Eurasian Blackbird',
+        confidence: 0.85,
+        timestamp: DateTime(2026, 5, 6, 12, 0, 0),
+        reviewStatus: ReviewStatus.confirmed,
+        reviewedAt: stamp,
+      );
+      expect(record.toJson()['confirmedAt'], record.toJson()['reviewedAt']);
+    });
+
+    test('legacy JSON with confirmedAt upgrades to confirmed', () {
+      final json = {
+        'scientificName': 'Turdus merula',
+        'commonName': 'Eurasian Blackbird',
+        'confidence': 0.85,
+        'timestamp': '2026-05-06T12:00:00.000Z',
+        'confirmedAt': '2026-05-06T12:30:45.000Z',
+      };
+      final record = DetectionRecord.fromJson(json);
+      expect(record.reviewStatus, ReviewStatus.confirmed);
+      expect(
+        record.reviewedAt!.isAtSameMomentAs(
+          DateTime.utc(2026, 5, 6, 12, 30, 45),
+        ),
+        isTrue,
+      );
+    });
+
+    test('legacy JSON without confirmedAt deserializes as unreviewed', () {
       final json = {
         'scientificName': 'Turdus merula',
         'commonName': 'Eurasian Blackbird',
@@ -327,8 +393,45 @@ void main() {
         'timestamp': '2026-05-06T12:00:00.000Z',
       };
       final record = DetectionRecord.fromJson(json);
-      expect(record.confirmedAt, isNull);
+      expect(record.reviewStatus, ReviewStatus.unreviewed);
+      expect(record.reviewedAt, isNull);
       expect(record.isConfirmed, isFalse);
+      expect(record.isRejected, isFalse);
+    });
+
+    test('unknown persisted review status falls back to unreviewed', () {
+      final json = {
+        'scientificName': 'Turdus merula',
+        'commonName': 'Eurasian Blackbird',
+        'confidence': 0.85,
+        'timestamp': '2026-05-06T12:00:00.000Z',
+        'reviewStatus': 'deferred',
+      };
+      expect(
+        DetectionRecord.fromJson(json).reviewStatus,
+        ReviewStatus.unreviewed,
+      );
+    });
+
+    test('markConfirmed / markRejected / clearReview move between states', () {
+      final record = DetectionRecord(
+        scientificName: 'Turdus merula',
+        commonName: 'Eurasian Blackbird',
+        confidence: 0.85,
+        timestamp: DateTime.now(),
+      );
+
+      record.markConfirmed();
+      expect(record.isConfirmed, isTrue);
+      expect(record.reviewedAt!.isUtc, isTrue);
+
+      record.markRejected();
+      expect(record.isRejected, isTrue);
+      expect(record.isConfirmed, isFalse);
+
+      record.clearReview();
+      expect(record.reviewStatus, ReviewStatus.unreviewed);
+      expect(record.reviewedAt, isNull);
     });
 
     test('note defaults to null and hasNote is false', () {


### PR DESCRIPTION
Introduce a review status system for detections, replacing the previous confirmation mechanism. This change allows for states of confirmed, rejected, or unreviewed, enhancing the clarity of detection evaluations. Update related components to reflect the new review status and ensure proper handling in exports and UI displays.