### PR TITLE
fix: resolve Norwegian species names for Bokmål and Nynorsk locale

### DIFF
--- a/lib/shared/models/taxonomy_species.dart
+++ b/lib/shared/models/taxonomy_species.dart
@@ -191,6 +191,10 @@ class TaxonomySpecies {
     // Chinese app locale produces) or a Traditional tag would otherwise miss
     // every column and fall back to the English common name.
     if (parts.first == 'zh') yield 'zh-CN';
+
+    // Norwegian names live in `no`, but Bokmål is registered as `nb`
+    // and Nynorsk `nn`.
+    if (parts.first == 'nb' || parts.first == 'nn') yield 'no';
   }
 
   // ---------------------------------------------------------------------------

--- a/test/shared/models/taxonomy_species_test.dart
+++ b/test/shared/models/taxonomy_species_test.dart
@@ -311,6 +311,19 @@ void main() {
       expect(sp.commonNameForLocale('zh-Hans'), '大山雀');
       expect(sp.commonNameForLocale('zh-TW'), '大山雀');
     });
+
+    // The Bokmål app locale is `nb` and a Norwegian phones report `nb`/`nb-NO`,
+    // but the species list uses `no`. Same problem with Nynorsk `nn`.
+    test('commonNameForLocale resolves Norwegian tags to no', () {
+      const sp = TaxonomySpecies(
+        scientificName: 'Parus major',
+        commonName: 'Great Tit',
+        commonNames: {'no': 'kjøttmeis'},
+      );
+      expect(sp.commonNameForLocale('nb'), 'kjøttmeis');
+      expect(sp.commonNameForLocale('nb-NO'), 'kjøttmeis');
+      expect(sp.commonNameForLocale('nn'), 'kjøttmeis');
+    });
   });
 
   // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
- Currently, when a norwegian opens the app, we get the Norwegian locale, but the species are still in english
- This pr adds a logic, that falls back Norsk Bokmål nb-NO and Nynorsk nn-NO to the "no" language list.

## Note: 
Worth to note, the Norwegian species list is not strictly correct for Nynorsk, but its a lot better than English.
Example: Sparrow.  Bokmål: Spurv, Nynorsk: Sporv (https://ordbokene.no/nob/nn/sporv) 
Example: Seagull.  Bokmål: Måke, Nynorsk: Måke/Måse (both allowed)
But thats an issue from the birdnet species list. 