### PR TITLE
fix(recording): await ranged decodes for Flutter 3.47's new lint

### DIFF
--- a/lib/features/recording/audio_decoder.dart
+++ b/lib/features/recording/audio_decoder.dart
@@ -433,13 +433,17 @@ class AudioDecoder {
           header[1] == 0x49 &&
           header[2] == 0x46 &&
           header[3] == 0x46) {
-        return _decodeWavRange(file, startSample: startSample, count: count);
+        return await _decodeWavRange(
+          file,
+          startSample: startSample,
+          count: count,
+        );
       }
       if (header[0] == 0x66 &&
           header[1] == 0x4C &&
           header[2] == 0x61 &&
           header[3] == 0x43) {
-        return decodeFlacRange(
+        return await decodeFlacRange(
           path,
           startSample: startSample,
           count: count,


### PR DESCRIPTION
CI runs Flutter 3.47.2, which added the `unawaited_return_in_try_block` lint. `main` trips it twice, so `flutter analyze --no-fatal-infos` exits 1 and every open PR fails CI regardless of what it changes (#170, #225, #226, #227 are all red on these two warnings). Nothing is wrong with those branches — the lint is new, not the code.

```
warning • Returning a 'Future' without 'await' inside a try block • lib/features/recording/audio_decoder.dart:436:9 • unawaited_return_in_try_block
warning • Returning a 'Future' without 'await' inside a try block • lib/features/recording/audio_decoder.dart:442:9 • unawaited_return_in_try_block
```

`AudioDecoder.decodeRange` returns `_decodeWavRange(...)` / `decodeFlacRange(...)` from inside a `try` whose `finally` does `await raf.close()`. Without `await`, the future is handed back before the block completes, so the header handle closes while the decode is still pending. Adding `await` is both what the lint asks for and what the code already intends.

No behavior change: both callees open their own handles (`_readWavInfo` for WAV, a fresh `RandomAccessFile` for FLAC), so the early close never affected them.

**Verified on Flutter 3.47.2:** `flutter analyze --no-fatal-infos` on `main` reports these 2 issues; with this change the full repo reports `No issues found`. `flutter test test/features/recording test/features/history` — 337 pass.

Note, separately: on 3.47 both `pub get` and `analyze` rewrite `analysis_options.yaml` to add an `analyzer: exclude:` block for `build/`, `android/`, `ios/`, `windows/`. It regenerates on every run and dirties the tree for anyone on 3.47 — probably worth committing deliberately, but I've left it out of this PR.

Also unrelated: #227 has additional failures (`undefined_getter` on `List<PlatformFile>.files`, looks like a `file_picker` API change) that this doesn't address.
