### PR TITLE
fix(widget): opt android widget out of lock-screen slots on API 36+

### DIFF
--- a/android/app/src/main/res/xml-v36/quick_listen_widget_1x1_info.xml
+++ b/android/app/src/main/res/xml-v36/quick_listen_widget_1x1_info.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- API 36+ variant of xml/quick_listen_widget_1x1_info.xml; see
+     xml-v36/quick_listen_widget_info.xml for why "not_keyguard" is set and why
+     this is a full copy rather than an overlay. -->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="40dp"
+    android:minHeight="40dp"
+    android:targetCellWidth="1"
+    android:targetCellHeight="1"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/quick_listen_widget_1x1"
+    android:previewLayout="@layout/quick_listen_widget_1x1"
+    android:description="@string/quick_listen_widget_1x1_description"
+    android:resizeMode="none"
+    android:widgetCategory="home_screen|not_keyguard"
+    android:previewImage="@mipmap/ic_launcher" />

--- a/android/app/src/main/res/xml-v36/quick_listen_widget_info.xml
+++ b/android/app/src/main/res/xml-v36/quick_listen_widget_info.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- API 36+ variant of xml/quick_listen_widget_info.xml. Identical except for
+     the added "not_keyguard" category: from Android 16, widgets are eligible
+     for lock-screen slots unless they opt out, and this one launches an
+     activity, which the lock screen cannot do without authenticating first.
+     Offering the tile there would only ever produce an unlock prompt. See
+     https://android-developers.googleblog.com/2025/03/widgets-on-lock-screen-faq.html
+
+     This file must stay a full copy — a qualified resource replaces the
+     unqualified one outright rather than merging with it. Keep the two in
+     sync when editing either. -->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="110dp"
+    android:minHeight="40dp"
+    android:targetCellWidth="2"
+    android:targetCellHeight="1"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/quick_listen_widget"
+    android:previewLayout="@layout/quick_listen_widget"
+    android:description="@string/quick_listen_widget_description"
+    android:resizeMode="horizontal"
+    android:widgetCategory="home_screen|not_keyguard"
+    android:previewImage="@mipmap/ic_launcher" />


### PR DESCRIPTION
Closes #230.

This adds API 36+ variants of both appwidget-info files declaring `home_screen|not_keyguard`, so the tile is no longer offered on the lock screen. The unqualified `xml/` files are untouched, so pre-36 devices are unaffected.

**This does not make Quick Listen work from the lock screen** - making it work from the lock screen needs either `showWhenLocked` on `MainActivity`, which would expose session history, recorded locations, and species records over the keyguard, or a no-UI trampoline activity. 

**Verification:** confirmed on a Pixel 9 Pro running Android 17 (SDK 37). The system parses both providers as `widgetCategory=9` (`home_screen|not_keyguard`); the widget is no longer offered in the lock-screen picker and is still available on the home screen. `:app:assembleDebug` passes.