### PR TITLE
Fix Raven selection table timing and audio references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Raven selection tables now use cumulative clip-sequence times, omit detections without exported clips, always report Survey Time in UTC, and keep Raven’s default columns first. Document-only Raven clip exports reference the original audio filenames (#229).
+
 ## [1.1.3] - 2026-09-10
 
 ### Changed

--- a/lib/features/history/services/detection_sharing_service.dart
+++ b/lib/features/history/services/detection_sharing_service.dart
@@ -207,10 +207,13 @@ LiveSession _singleDetectionSession({
               detection.endTimestamp!.isAfter(detection.timestamp)
           ? detection.endTimestamp!
           : detection.timestamp.add(Duration(seconds: settings.windowDuration));
+  // Document-only exports still need the source clip reference.
   final exportDetection = _copyDetection(
     detection,
     audioClipPath:
-        audioFile != null && !audioIsFullDetectionSpan ? audioFile.path : null,
+        audioIsFullDetectionSpan
+            ? null
+            : audioFile?.path ?? detection.audioClipPath,
   );
 
   return LiveSession(

--- a/lib/features/history/session_export.dart
+++ b/lib/features/history/session_export.dart
@@ -201,27 +201,13 @@ String _evidenceField(DetectionRecord d) => switch (d.evidence) {
 String _displaySci(DetectionRecord d, {TaxonomyService? taxonomy}) =>
     taxonomy?.displayScientificName(d.scientificName) ?? d.scientificName;
 
-/// Generates a Raven Pro-compatible selection table from session detections.
+/// Generates a Raven-compatible selection table from session detections.
 ///
-/// When [audioFileName] is provided every row references that single file.
-/// When [clipFileMap] is provided (detection index → clip filename), rows with
-/// a clip reference that file; rows without a clip get an empty `Begin File`.
-///
-/// Time semantics:
-///   • For rows referencing a per-detection **clip**, `Begin/End Time` are
-///     offsets *within the clip*. With pre/post context of
-///     [SessionSettings.clipContextSeconds] seconds, the detection starts
-///     after the available pre-roll and ends at [DetectionRecord.endTimestamp]
-///     when present, otherwise after one inference window.
-///   • For rows referencing the **full recording** (or no audio), `Begin/End
-///     Time` are session-relative offsets.
-///   • A `Survey Time` column is always appended so analysts can recover the
-///     timeline of every detection regardless of file layout. By default this
-///     is `Survey Time (s)` (seconds since session start). When
-///     [useAbsoluteSurveyTime] is true the column becomes `Survey Time (UTC)`
-///     and carries the detection's wall-clock timestamp as an ISO-8601 UTC
-///     string — useful when correlating across surveys, devices, or external
-///     data sources that work in absolute time.
+/// [clipFileMap] maps detection indices to exported filenames in sound-file
+/// sequence order. Only those detections are emitted, with Begin/End Time
+/// measured along the cumulative clip sequence. Without a clip map, times
+/// index the full recording (including gap removal and export trimming).
+/// Survey Time always carries the detection's absolute UTC timestamp.
 ///
 /// Common Name is rendered in the user's species locale when [taxonomy] is
 /// supplied; Scientific Name is always emitted regardless of any UI toggle
@@ -236,7 +222,6 @@ String buildRavenSelectionTable(
   TaxonomyService? taxonomy,
   String speciesLocale = 'en',
   int? clipContextSecondsOverride,
-  bool useAbsoluteSurveyTime = false,
 }) {
   final buf = StringBuffer();
   final hasCoords = session.detections.any(
@@ -252,23 +237,13 @@ String buildRavenSelectionTable(
       (clipContextSecondsOverride ?? session.settings.clipContextSeconds)
           .toDouble();
 
-  // Header row — 'Begin File' is a standard Raven column for multi-file
-  // selection tables. 'Survey Time' is non-standard but harmless to Raven
-  // (extra columns are ignored on import) and lets analysts cross-reference
-  // detections back to the survey timeline. We always emit it: when no clips
-  // are involved it duplicates Begin Time, but having a stable column name
-  // makes downstream tooling simpler than conditionally including it.
-  // 'Review Status' / 'Reviewed At (UTC)' are likewise always emitted so the
-  // schema is stable regardless of whether the session has any reviewed
-  // detections; unreviewed rows carry an empty 'Reviewed At'.
-  final surveyTimeHeader =
-      useAbsoluteSurveyTime ? 'Survey Time (UTC)' : 'Survey Time (s)';
+  // Raven requires its seven default fields before any additional fields.
   buf.writeln(
-    'Selection\tView\tChannel\tBegin File\t'
+    'Selection\tView\tChannel\t'
     'Begin Time (s)\tEnd Time (s)\t'
-    'Low Freq (Hz)\tHigh Freq (Hz)\t'
+    'Low Freq (Hz)\tHigh Freq (Hz)\tBegin File\t'
     'Common Name\tScientific Name\tConfidence'
-    '\t$surveyTimeHeader'
+    '\tSurvey Time (UTC)'
     '\tReview Status\tReviewed At (UTC)'
     '${hasCoords ? '\tLatitude\tLongitude' : ''}'
     '${hasEvidence ? '\tEvidence' : ''}'
@@ -280,11 +255,14 @@ String buildRavenSelectionTable(
   // gap-removed timeline so resumed sessions don't include stopped time.
   final sessionDurationSec = _recordedTimelineDurationSeconds(session);
 
-  for (var i = 0; i < session.detections.length; i++) {
+  final indices =
+      clipFileMap?.keys ?? Iterable<int>.generate(session.detections.length);
+  var selection = 0;
+  var clipSequenceOffset = 0.0;
+  for (final i in indices) {
     final d = session.detections[i];
     final isGlobal = d.source == DetectionSource.manualGlobal;
 
-    // File reference: clip name (if available) > full recording > empty.
     final clipName = clipFileMap?[i];
     final beginFile = clipName ?? audioFileName ?? '';
     final referencesClip = clipName != null;
@@ -295,26 +273,18 @@ String buildRavenSelectionTable(
       clipContextSeconds: clipContext,
       referencesDetectionClip: referencesClip,
     );
-    // Session-relative offset (always computed; used for either Begin Time
-    // or the auxiliary Survey Time column), rebased onto the exported
-    // (possibly trimmed) audio so it indexes the file the row references.
-    final surveySec =
-        isGlobal
-            ? 0.0
-            : _exportTimelineOffset(session, timing.detectionStartSec);
-
     // Begin/End times depend on whether the row references a clip file.
     final double beginSec;
     final double endSec;
     if (referencesClip) {
-      // Inside the clip: detection sits after the pre-roll context.
-      beginSec = timing.clipDetectionStartSec;
-      endSec = timing.clipDetectionEndSec;
+      beginSec = clipSequenceOffset + timing.clipDetectionStartSec;
+      endSec = clipSequenceOffset + timing.clipDetectionEndSec;
+      clipSequenceOffset += timing.clipDurationSec;
     } else if (isGlobal) {
       beginSec = 0.0;
       endSec = sessionDurationSec;
     } else {
-      beginSec = surveySec;
+      beginSec = _exportTimelineOffset(session, timing.detectionStartSec);
       endSec = _exportTimelineOffset(session, timing.detectionEndSec);
     }
 
@@ -324,11 +294,7 @@ String buildRavenSelectionTable(
       speciesLocale: speciesLocale,
     );
 
-    final surveyTimeValue =
-        useAbsoluteSurveyTime
-            ? d.timestamp.toUtc().toIso8601String()
-            : surveySec.toStringAsFixed(3);
-    final surveyTimeSuffix = '\t$surveyTimeValue';
+    final surveyTimeSuffix = '\t${d.timestamp.toUtc().toIso8601String()}';
     final reviewSuffix =
         '\t${d.reviewStatus.name}'
         '\t${d.reviewedAt?.toUtc().toIso8601String() ?? ''}';
@@ -348,14 +314,14 @@ String buildRavenSelectionTable(
             : '';
 
     buf.writeln(
-      '${i + 1}\t'
+      '${++selection}\t'
       'Spectrogram 1\t'
       '1\t'
-      '$beginFile\t'
       '${beginSec.toStringAsFixed(3)}\t'
       '${endSec.toStringAsFixed(3)}\t'
       '0\t'
       '$_highFreqHz\t'
+      '$beginFile\t'
       '$commonName\t'
       '${_displaySci(d, taxonomy: taxonomy)}\t'
       '${d.confidence.toStringAsFixed(4)}'
@@ -404,9 +370,8 @@ String buildCsvExport(
       (clipContextSecondsOverride ?? session.settings.clipContextSeconds)
           .toDouble();
 
-  // Survey Time is always included (see [buildRavenSelectionTable] for the
-  // rationale). When [useAbsoluteSurveyTime] is true the column becomes
-  // 'Survey Time (UTC)' and carries an ISO-8601 wall-clock timestamp.
+  // Survey Time is always included. When [useAbsoluteSurveyTime] is true,
+  // the column becomes 'Survey Time (UTC)' with an ISO-8601 timestamp.
   // 'Review Status' / 'Reviewed At (UTC)' are always emitted so downstream
   // pipelines see a stable schema; unreviewed rows carry an empty
   // 'Reviewed At'.
@@ -1029,6 +994,10 @@ Future<String?> buildSessionExport(
     }
   }
   final hasClips = clipEntries.isNotEmpty;
+  final usesDetectionClips =
+      !hasFullRecording &&
+      (session.settings.recordingMode == 'detections' ||
+          session.detections.any((d) => (d.audioClipPath ?? '').isNotEmpty));
   final hasAnyAudio = hasFullRecording || hasClips;
 
   // ── Build export clip names (sequential, 1-indexed, zero-padded) ────
@@ -1086,6 +1055,17 @@ Future<String?> buildSessionExport(
     }
     clipFileMap = clipExportNames;
   }
+
+  // Unbundled Raven audio references identify the existing source files.
+  final ravenClipFileMap =
+      usesDetectionClips
+          ? (includeAudio
+              ? clipExportNames
+              : <int, String>{
+                for (final i in clipExportNames.keys)
+                  i: p.basename(clipEntries[i]!.path),
+              })
+          : null;
 
   final aruCycleAudioEntries = <int, ({File file, String name})>{};
   final aruCycles = session.aruMetadata?.cycles ?? const <AruCycleMetadata>[];
@@ -1162,11 +1142,10 @@ Future<String?> buildSessionExport(
           content: buildRavenSelectionTable(
             session,
             audioFileName: hasFullRecording ? audioFileName : null,
-            clipFileMap: clipFileMap,
+            clipFileMap: ravenClipFileMap,
             taxonomy: taxonomy,
             speciesLocale: speciesLocale,
             clipContextSecondsOverride: clipContextSecondsOverride,
-            useAbsoluteSurveyTime: useAbsoluteSurveyTime,
           ),
         );
         break;

--- a/test/features/history/detection_sharing_service_test.dart
+++ b/test/features/history/detection_sharing_service_test.dart
@@ -463,6 +463,113 @@ void main() {
       expect(params.files!.single.mimeType, 'text/csv');
     });
 
+    for (final scenario in [
+      (includeAudio: false, asWav: false, exists: true),
+      (includeAudio: false, asWav: true, exists: true),
+      (includeAudio: false, asWav: false, exists: false),
+      (includeAudio: false, asWav: true, exists: false),
+      (includeAudio: true, asWav: true, exists: true),
+    ]) {
+      test('Raven detection share $scenario', () async {
+        final start = DateTime.utc(2026, 5, 11, 10);
+        final clip = File(p.join(tmp.path, 'original-field-recording.flac'));
+        await FlacEncoder.writeFile(
+          filePath: clip.path,
+          samples: _pcmLikeFloatSamples(32000 * 5),
+        );
+        final originalBytes = await clip.readAsBytes();
+        if (!scenario.exists) await clip.delete();
+        final detection = _det(start)..audioClipPath = clip.path;
+        final session = LiveSession(
+          id: 'raven-only',
+          startTime: start,
+          detections: [detection],
+          settings: const SessionSettings(
+            windowDuration: 3,
+            confidenceThreshold: 25,
+            inferenceRate: 1,
+            speciesFilterMode: 'off',
+            clipContextSeconds: 1,
+            recordingMode: 'detections',
+          ),
+        );
+
+        await shareDetection(
+          detection,
+          session: session,
+          formats: const {'raven'},
+          includeAudio: scenario.includeAudio,
+          shareAudioAsWav: scenario.asWav,
+        );
+
+        final files = fakeSharePlatform.lastParams!.files!;
+        expect(files, hasLength(1));
+        final String table;
+        Archive? archive;
+        if (scenario.includeAudio) {
+          expect(files.single.name, endsWith('.zip'));
+          archive = ZipDecoder().decodeBytes(
+            await File(files.single.path).readAsBytes(),
+          );
+          table = utf8.decode(
+            archive
+                    .firstWhere((file) => file.name.endsWith('.selections.txt'))
+                    .content
+                as List<int>,
+          );
+        } else {
+          expect(files.single.name, endsWith('.selections.txt'));
+          table = await File(files.single.path).readAsString();
+          final audioFiles =
+              tmp
+                  .listSync(recursive: true)
+                  .whereType<File>()
+                  .where(
+                    (file) =>
+                        ['.wav', '.flac'].contains(p.extension(file.path)),
+                  )
+                  .map((file) => file.path)
+                  .toList();
+          expect(audioFiles, scenario.exists ? [clip.path] : isEmpty);
+        }
+        final rows =
+            table
+                .split('\n')
+                .where((line) => line.isNotEmpty)
+                .map((line) => line.split('\t'))
+                .toList();
+        expect(rows, hasLength(scenario.exists ? 2 : 1));
+        if (scenario.exists) {
+          final header = rows.first;
+          final row = rows[1];
+          expect(row.length, header.length);
+          expect(row[header.indexOf('Selection')], '1');
+          expect(row[header.indexOf('Begin Time (s)')], '1.000');
+          expect(row[header.indexOf('End Time (s)')], '4.000');
+          final beginFile = row[header.indexOf('Begin File')];
+          if (scenario.includeAudio) {
+            expect(beginFile, endsWith('_clip_001_Eurasian_Wren.wav'));
+            expect(
+              archive!
+                  .where((file) => file.name.endsWith('.wav'))
+                  .map((file) => file.name),
+              [beginFile],
+            );
+          } else {
+            expect(beginFile, 'original-field-recording.flac');
+            expect(table, isNot(contains('_clip_001_')));
+          }
+          expect(
+            row[header.indexOf('Survey Time (UTC)')],
+            '2026-05-11T10:00:00.000Z',
+          );
+        }
+        expect(detection.audioClipPath, clip.path);
+        expect(clip.existsSync(), scenario.exists);
+        if (scenario.exists) expect(await clip.readAsBytes(), originalBytes);
+      });
+    }
+
     test('can share only the selected app metadata', () async {
       final start = DateTime.utc(2026, 5, 11, 10);
       final session = _session(recordingPath: '', start: start);

--- a/test/features/history/session_export_test.dart
+++ b/test/features/history/session_export_test.dart
@@ -22,6 +22,7 @@ LiveSession _makeSession({
   String? recordingPath,
   int windowDuration = 3,
   int clipContextSeconds = 0,
+  String? recordingMode,
   SessionType type = SessionType.live,
 }) {
   final start = DateTime.utc(2025, 6, 15, 8, 0, 0);
@@ -38,6 +39,7 @@ LiveSession _makeSession({
       inferenceRate: 1.0,
       speciesFilterMode: 'off',
       clipContextSeconds: clipContextSeconds,
+      recordingMode: recordingMode,
     ),
   );
 }
@@ -120,6 +122,16 @@ void main() {
       final table = buildRavenSelectionTable(session);
       final header = table.split('\n').first;
 
+      expect(header.split('\t').take(8), [
+        'Selection',
+        'View',
+        'Channel',
+        'Begin Time (s)',
+        'End Time (s)',
+        'Low Freq (Hz)',
+        'High Freq (Hz)',
+        'Begin File',
+      ]);
       expect(header, contains('Selection'));
       expect(header, contains('View'));
       expect(header, contains('Channel'));
@@ -184,8 +196,20 @@ void main() {
           .toList()[1]
           .split('\t');
 
-      expect(cols[4], '310.000'); // Begin Time (gap removed)
-      expect(cols[5], '313.000'); // End Time (310 + 3)
+      expect(cols[3], '310.000'); // Begin Time (gap removed)
+      expect(cols[4], '313.000'); // End Time (310 + 3)
+
+      session.detections.insert(
+        0,
+        _det('Parus major', 'Great Tit', 0.8, Duration.zero, start),
+      );
+      final clipRows = buildRavenSelectionTable(
+        session,
+        clipFileMap: {0: 'first.wav', 1: 'resumed.wav'},
+        clipContextSecondsOverride: 1,
+      ).split('\n');
+      expect(clipRows[2].split('\t').sublist(3, 5), ['6.000', '9.000']);
+      expect(clipRows[2].split('\t')[11], '2025-06-15T08:35:10.000Z');
     });
 
     test('resumed session: global annotation ends at recorded duration', () {
@@ -224,8 +248,8 @@ void main() {
       );
 
       final cols = buildRavenSelectionTable(session).split('\n')[1].split('\t');
-      expect(cols[4], '0.000');
-      expect(cols[5], '600.000');
+      expect(cols[3], '0.000');
+      expect(cols[4], '600.000');
     });
 
     test('empty detections produces header only', () {
@@ -266,16 +290,16 @@ void main() {
 
       expect(lines.length, 3); // header + 2 detections
 
-      // First detection â€” columns shifted by Begin File.
+      // First detection.
       final cols1 = lines[1].split('\t');
       expect(cols1[0], '1'); // Selection
       expect(cols1[1], 'Spectrogram 1'); // View
       expect(cols1[2], '1'); // Channel
-      expect(cols1[3], '$_prefix.wav'); // Begin File
-      expect(cols1[4], '10.000'); // Begin Time
-      expect(cols1[5], '13.000'); // End Time (10 + 3)
-      expect(cols1[6], '0'); // Low Freq
-      expect(cols1[7], '16000'); // High Freq
+      expect(cols1[7], '$_prefix.wav'); // Begin File
+      expect(cols1[3], '10.000'); // Begin Time
+      expect(cols1[4], '13.000'); // End Time (10 + 3)
+      expect(cols1[5], '0'); // Low Freq
+      expect(cols1[6], '16000'); // High Freq
       expect(cols1[8], 'Eurasian Blackbird'); // Common Name
       expect(cols1[9], 'Turdus merula'); // Scientific Name
       expect(cols1[10], '0.9500'); // Confidence
@@ -283,64 +307,151 @@ void main() {
       // Second detection.
       final cols2 = lines[2].split('\t');
       expect(cols2[0], '2');
-      expect(cols2[3], '$_prefix.wav');
-      expect(cols2[4], '25.500'); // 25.5 seconds
-      expect(cols2[5], '28.500'); // 25.5 + 3
+      expect(cols2[7], '$_prefix.wav');
+      expect(cols2[3], '25.500'); // 25.5 seconds
+      expect(cols2[4], '28.500'); // 25.5 + 3
       expect(cols2[8], 'European Robin');
     });
 
-    test(
-      'clip mode: Begin/End Time are in-clip offsets and a Survey Time column is added',
-      () {
-        final start = DateTime.utc(2025, 6, 15, 8, 0, 0);
-        final session = _makeSession(
-          windowDuration: 3,
-          clipContextSeconds: 1,
-          detections: [
-            _det(
-              'Turdus merula',
-              'Eurasian Blackbird',
-              0.95,
-              const Duration(seconds: 10),
-              start,
-            ),
-            _det(
-              'Erithacus rubecula',
-              'European Robin',
-              0.72,
-              const Duration(seconds: 25),
-              start,
-            ),
-          ],
-        );
+    test('clip mode: Begin/End Time follow the sound-file sequence', () {
+      final start = DateTime.utc(2025, 6, 15, 8, 0, 0);
+      final session = _makeSession(
+        windowDuration: 3,
+        clipContextSeconds: 1,
+        detections: [
+          _det(
+            'Turdus merula',
+            'Eurasian Blackbird',
+            0.95,
+            const Duration(seconds: 10),
+            start,
+          ),
+          _det(
+            'Erithacus rubecula',
+            'European Robin',
+            0.72,
+            const Duration(seconds: 25),
+            start,
+          ),
+        ],
+      );
 
-        final table = buildRavenSelectionTable(
+      final table = buildRavenSelectionTable(
+        session,
+        clipFileMap: {
+          0: '${_prefix}_clip_001_Eurasian_Blackbird.flac',
+          1: '${_prefix}_clip_002_European_Robin.flac',
+        },
+      );
+      final lines = table.split('\n').where((l) => l.isNotEmpty).toList();
+
+      expect(lines.first, contains('Survey Time (UTC)'));
+
+      final cols1 = lines[1].split('\t');
+      expect(cols1[7], '${_prefix}_clip_001_Eurasian_Blackbird.flac');
+      // Detection sits at [clipContext, clipContext + window] inside the clip.
+      expect(cols1[3], '1.000');
+      expect(cols1[4], '4.000');
+      // Survey Time retains the absolute detection timestamp.
+      expect(cols1[11], '2025-06-15T08:00:10.000Z');
+
+      final cols2 = lines[2].split('\t');
+      expect(cols2[7], '${_prefix}_clip_002_European_Robin.flac');
+      expect(cols2[3], '6.000');
+      expect(cols2[4], '9.000');
+      expect(cols2[11], '2025-06-15T08:00:25.000Z');
+    });
+
+    test('clip sequence follows map order and the context override', () {
+      final start = DateTime.utc(2025, 6, 15, 8);
+      final session = _makeSession(
+        windowDuration: 5,
+        detections: List.generate(
+          4,
+          (i) => _det(
+            'Turdus merula',
+            'Eurasian Blackbird',
+            0.9,
+            Duration(seconds: i * 20),
+            start,
+            endOffset: Duration(seconds: i * 20 + 15),
+          ),
+        ),
+      );
+      session.trimStartSec = 10;
+      session.trimEndSec = 50;
+      final rows = buildRavenSelectionTable(
+        session,
+        clipFileMap: {3: 'first.wav', 0: 'second.wav'},
+        clipContextSecondsOverride: 2,
+      ).split('\n');
+      expect(rows[1].split('\t').sublist(3, 5), ['2.000', '7.000']);
+      expect(rows[2].split('\t').sublist(3, 5), ['11.000', '16.000']);
+      expect(rows[1].split('\t')[7], 'first.wav');
+      expect(rows[2].split('\t')[7], 'second.wav');
+      expect(rows.where((row) => row.isNotEmpty).length, 3);
+      expect(
+        buildRavenSelectionTable(
           session,
-          clipFileMap: {
-            0: '${_prefix}_clip_001_Eurasian_Blackbird.flac',
-            1: '${_prefix}_clip_002_European_Robin.flac',
-          },
+          clipFileMap: {},
+        ).split('\n').where((row) => row.isNotEmpty).length,
+        1,
+      );
+    });
+
+    test('optional fields keep every Raven row structurally valid', () {
+      final start = DateTime.utc(2025, 6, 15, 8);
+      final plain = _det('Parus major', 'Great Tit', 0.8, Duration.zero, start);
+      final annotated = DetectionRecord(
+        scientificName: 'Turdus merula',
+        commonName: 'Eurasian Blackbird',
+        confidence: 0.9,
+        timestamp: start.add(const Duration(seconds: 10)),
+        latitude: 52.52,
+        longitude: 13.405,
+        note: ' first\tsecond\r\nthird\nfourth ',
+        evidence: DetectionEvidence.heardAndSeen,
+        reviewStatus: ReviewStatus.confirmed,
+        reviewedAt: start,
+      );
+      for (final detections in [
+        [plain],
+        [annotated, plain],
+      ]) {
+        final table = buildRavenSelectionTable(
+          _makeSession(detections: detections),
         );
-        final lines = table.split('\n').where((l) => l.isNotEmpty).toList();
-
-        // Header gains 'Survey Time (s)' when any row references a clip.
-        expect(lines.first, contains('Survey Time (s)'));
-
-        final cols1 = lines[1].split('\t');
-        expect(cols1[3], '${_prefix}_clip_001_Eurasian_Blackbird.flac');
-        // Detection sits at [clipContext, clipContext + window] inside the clip.
-        expect(cols1[4], '1.000');
-        expect(cols1[5], '4.000');
-        // Survey Time column carries the session-relative offset.
-        expect(cols1[11], '10.000');
-
-        final cols2 = lines[2].split('\t');
-        expect(cols2[3], '${_prefix}_clip_002_European_Robin.flac');
-        expect(cols2[4], '1.000');
-        expect(cols2[5], '4.000');
-        expect(cols2[11], '25.000');
-      },
-    );
+        final lines = table.split('\n');
+        expect(lines.removeLast(), ''); // One final line terminator.
+        final header = lines.first.split('\t');
+        for (final line in lines) {
+          expect(line, isNotEmpty);
+          expect(line.split('\t').length, header.length);
+        }
+        for (final line in lines.skip(1)) {
+          final fields = line.split('\t');
+          for (final index in [0, 2, 3, 4, 5, 6]) {
+            expect(double.parse(fields[index]).isFinite, isTrue);
+          }
+        }
+        if (header.contains('Note')) {
+          expect(
+            lines[1].split('\t')[header.indexOf('Note')],
+            'first second third fourth',
+          );
+          final empty = lines[2].split('\t');
+          for (final column in [
+            'Latitude',
+            'Longitude',
+            'Note',
+            'Evidence',
+            'Reviewed At (UTC)',
+          ]) {
+            expect(empty[header.indexOf(column)], '');
+          }
+        }
+      }
+    });
 
     test('no file refs: Begin File column is empty', () {
       final start = DateTime.utc(2025, 6, 15, 8, 0, 0);
@@ -358,8 +469,8 @@ void main() {
 
       final table = buildRavenSelectionTable(session);
       final cols = table.split('\n')[1].split('\t');
-      expect(cols[3], ''); // Begin File empty
-      expect(cols[4], '7.000'); // Begin Time still works
+      expect(cols[7], ''); // Begin File empty
+      expect(cols[3], '7.000'); // Begin Time still works
     });
 
     test('uses session window duration for end time', () {
@@ -381,8 +492,8 @@ void main() {
       final lines = table.split('\n').where((l) => l.isNotEmpty).toList();
       final cols = lines[1].split('\t');
 
-      expect(cols[4], '7.000'); // Begin
-      expect(cols[5], '12.000'); // End (7 + 5)
+      expect(cols[3], '7.000'); // Begin
+      expect(cols[4], '12.000'); // End (7 + 5)
     });
 
     test('uses endTimestamp for continuous detections in full recordings', () {
@@ -407,8 +518,8 @@ void main() {
       );
       final cols = table.split('\n')[1].split('\t');
 
-      expect(cols[4], '5.000');
-      expect(cols[5], '19.000');
+      expect(cols[3], '5.000');
+      expect(cols[4], '19.000');
     });
 
     test('clip rows cover one analysis window for continuous detections', () {
@@ -434,9 +545,9 @@ void main() {
       );
       final cols = table.split('\n')[1].split('\t');
 
-      expect(cols[4], '1.000');
-      expect(cols[5], '4.000');
-      expect(cols[11], '5.000');
+      expect(cols[3], '1.000');
+      expect(cols[4], '4.000');
+      expect(cols[11], '2025-06-15T08:00:05.000Z');
     });
 
     test('includes Latitude/Longitude when detections have coordinates', () {
@@ -504,13 +615,13 @@ void main() {
         session,
         audioFileName: '$_prefix.wav',
       );
-      expect(table.split('\n').first, contains('Survey Time (s)'));
+      expect(table.split('\n').first, contains('Survey Time (UTC)'));
       final cols = table.split('\n')[1].split('\t');
-      expect(cols[11], '10.000');
+      expect(cols[11], '2025-06-15T08:00:10.000Z');
     });
 
-    test('useAbsoluteSurveyTime renames column and emits ISO UTC value', () {
-      final start = DateTime.utc(2025, 6, 15, 8, 0, 0);
+    test('Survey Time emits ISO UTC without a display preference', () {
+      final start = DateTime.utc(2025, 6, 15, 8, 0, 0).toLocal();
       final session = _makeSession(
         detections: [
           _det(
@@ -526,7 +637,6 @@ void main() {
       final table = buildRavenSelectionTable(
         session,
         audioFileName: '$_prefix.wav',
-        useAbsoluteSurveyTime: true,
       );
       final header = table.split('\n').first;
       expect(header, contains('Survey Time (UTC)'));
@@ -679,6 +789,35 @@ void main() {
       },
     );
 
+    test('clip mode without saved paths exports a Raven header only', () async {
+      final session = _makeSession(
+        recordingMode: 'detections',
+        detections: [
+          _det(
+            'Turdus merula',
+            'Eurasian Blackbird',
+            0.9,
+            Duration.zero,
+            DateTime.utc(2025, 6, 15, 8),
+          ),
+        ],
+      );
+      final path = await buildSessionExport(
+        session,
+        formats: const {'raven'},
+        includeAudio: true,
+      );
+      expect(path, isNotNull);
+      final lines =
+          File(path!)
+              .readAsStringSync()
+              .split('\n')
+              .where((row) => row.isNotEmpty)
+              .toList();
+      expect(lines, hasLength(1));
+      expect(lines.single, startsWith('Selection\t'));
+    });
+
     test(
       'creates a ZIP with wav and selection table (full recording)',
       () async {
@@ -785,6 +924,113 @@ void main() {
       expect(tableContent, contains('_clip_001_Eurasian_Blackbird.flac'));
       expect(tableContent, contains('_clip_002_European_Robin.flac'));
     });
+
+    for (final retained in [
+      List.generate(10, (i) => i),
+      [0, 3, 8],
+      <int>[],
+    ]) {
+      test('Raven ZIP sequence with ${retained.length} of 10 clips', () async {
+        final start = DateTime.utc(2025, 6, 15, 8);
+        final detections = <DetectionRecord>[];
+        for (var i = 0; i < 10; i++) {
+          final path = p.join(tempDir.path, 'source_${10 - i}.wav');
+          if (retained.contains(i)) {
+            await WavWriter.writePcm16File(
+              filePath: path,
+              samples: Int16List(32000 * 5),
+              sampleRate: 32000,
+            );
+          }
+          detections.add(
+            _det(
+              'Turdus merula',
+              'Eurasian Blackbird',
+              0.9,
+              Duration(seconds: i * 10),
+              start,
+              audioClipPath: i == 1 && !retained.contains(i) ? null : path,
+            ),
+          );
+        }
+        final session = _makeSession(
+          recordingPath: tempDir.path,
+          clipContextSeconds: 1,
+          detections: detections,
+        );
+        String? previousTable;
+        for (final absolute in [false, true]) {
+          final zipPath = await buildSessionExport(
+            session,
+            formats: const {'raven', 'csv', 'json'},
+            includeAudio: true,
+            useAbsoluteSurveyTime: absolute,
+          );
+          expect(zipPath, isNotNull);
+          final archive = ZipDecoder().decodeBytes(
+            File(zipPath!).readAsBytesSync(),
+          );
+          String document(String extension) => utf8.decode(
+            archive.firstWhere((f) => f.name.endsWith(extension)).content
+                as List<int>,
+          );
+          final table = document('.selections.txt');
+          if (previousTable != null) expect(table, previousTable);
+          previousTable = table;
+          final rows =
+              table
+                  .split('\n')
+                  .where((row) => row.isNotEmpty)
+                  .map((row) => row.split('\t'))
+                  .toList();
+          final header = rows.removeAt(0);
+          expect(rows.length, retained.length);
+          final audioNames =
+              archive
+                  .where((f) => f.name.endsWith('.wav'))
+                  .map((f) => f.name)
+                  .toList();
+          expect(rows.map((row) => row[7]).toList(), audioNames);
+          expect(header[11], 'Survey Time (UTC)');
+          for (var i = 0; i < rows.length; i++) {
+            final row = rows[i];
+            expect(row.length, header.length);
+            expect(row[0], '${i + 1}');
+            expect(row[3], (i * 5 + 1).toStringAsFixed(3));
+            expect(row[4], (i * 5 + 4).toStringAsFixed(3));
+            expect(
+              row[7],
+              '${_prefix}_clip_${(i + 1).toString().padLeft(3, '0')}_Eurasian_Blackbird.wav',
+            );
+            expect(
+              row[11],
+              detections[retained[i]].timestamp.toUtc().toIso8601String(),
+            );
+            final audio = archive.firstWhere((f) => f.name == row[7]);
+            final extracted = File(p.join(tempDir.path, 'check.wav'))
+              ..writeAsBytesSync(audio.content as List<int>);
+            final info = await AudioDecoder.inspectFile(extracted.path);
+            expect(info.totalSamples / info.sampleRate, 5);
+          }
+          if (retained.length == 10) {
+            expect(rows.last.sublist(3, 5), ['46.000', '49.000']);
+          }
+          final csv =
+              document(
+                '.csv',
+              ).split('\n').where((row) => row.isNotEmpty).toList();
+          expect(csv.length, 11);
+          expect(
+            csv.first,
+            contains(absolute ? 'Survey Time (UTC)' : 'Survey Time (s)'),
+          );
+          expect(
+            (jsonDecode(document('.json')) as Map)['detections'],
+            hasLength(10),
+          );
+        }
+      });
+    }
 
     test('converts FLAC clips to valid WAV files in ZIP exports', () async {
       final clipDir = '${tempDir.path}/clips_wav';
@@ -2131,7 +2377,7 @@ void main() {
           .firstWhere((l) => l.contains('Turdus merula'))
           .split('\t');
       // Detection at 30 s of the recording is 20 s into a trim at 10 s.
-      expect(double.parse(ravenRow[4]), closeTo(20.0, 0.001));
+      expect(double.parse(ravenRow[3]), closeTo(20.0, 0.001));
 
       final csv = buildCsvExport(session, audioFileName: '$_prefix.wav');
       final csvRow = csv
@@ -2146,7 +2392,7 @@ void main() {
           .split('\n')
           .firstWhere((l) => l.contains('Erithacus rubecula'))
           .split('\t');
-      expect(double.parse(earlyRow[4]), 0.0);
+      expect(double.parse(earlyRow[3]), 0.0);
     });
 
     test('JSON offsets and trimmed duration follow the trim', () async {


### PR DESCRIPTION
This fixes #229 and corrects the way Raven selection tables are exported for detection clips.

Previously, each detection clip was effectively treated as its own timeline. With a 3-second analysis window and 1 second of context on either side, every clip would export as `1.000–4.000`, even though Raven measures Begin and End Time from the start of the full sound-file sequence.

For the same example, selections now look like:

* Clip 1: `1.000–4.000`
* Clip 2: `6.000–9.000`
* Clip 10: `46.000–49.000`

The cumulative offset follows the actual exported clip order and uses the existing `detectionAudioWindow()` values for clip duration and detection position.

## Other Raven export fixes

Detection-clip exports now only include selections where the corresponding audio is actually available. This matters when clip subsampling is enabled or clips have since been removed. Selection numbers are renumbered consecutively after filtering.

Raven `Survey Time` is now always exported as `Survey Time (UTC)` using the detection timestamp in UTC. It no longer follows the relative/absolute timestamp display preference used by the UI. CSV behaviour is unchanged and continues to honour that preference.

The standard Raven fields are also restored to the expected leading order:

`Selection`, `View`, `Channel`, `Begin Time (s)`, `End Time (s)`, `Low Freq (Hz)`, `High Freq (Hz)`

`Begin File` now follows those fields.

## Audio references

There was also an edge case in individual detection sharing.

For a document-only Raven export, where audio is deliberately not included, `Begin File` now uses the basename of the actual source clip rather than generating an export filename for a file that was never created.

For example:

`original-field-recording.flac`

If audio is included and renamed or converted for the export, `Begin File` instead uses the exact filename written to the ZIP.

If the source clip is genuinely missing, the Raven row is not emitted with a fabricated reference.

## What has not changed

Full-recording Raven timing is unchanged.

Existing handling for resumed sessions, gap-removed timelines and trimmed recordings is preserved. Recording, clip creation, subsampling and persistence behaviour are also unchanged.

CSV and JSON continue to retain detections even when their Raven audio clips are unavailable.

## Tests

Regression coverage now includes:

* cumulative clip timing, including the 10th clip at `46.000–49.000`
* subsampled and missing clips
* consecutive selection numbering
* clip sequence and ZIP ordering
* document-only audio references
* WAV conversion preferences with document-only exports
* included audio filenames
* UTC Survey Time
* Raven column ordering
* trimmed and resumed sessions
* row and column consistency
* notes containing tabs and newlines

Validation completed:

* focused history/export tests: 99 passed
* complete `test/features/history` suite: 224 passed
* `git diff --check`: passed
* `flutter analyze --no-pub`: no Dart issues; the existing missing `assets/species_data/` warning remains

`CHANGELOG.md` has been updated under `Unreleased`.

I have also inspected the generated Raven tables and ZIP contents directly. I do not have Raven Pro or Raven Workbench installed locally, so I have not been able to do a native import test. If that is considered a critical compatibility check for this change, then that will need to be verified before merge.

## References

Raven documentation on Begin/End Time across a sound-file sequence:

https://www.ravensoundsoftware.com/knowledge-base/measure-begin-time-end-time-and-length-of-sound-files/

Raven guidance on selection table structure and import errors:

https://www.ravensoundsoftware.com/knowledge-base/error-opening-selection-table/

Fixes #229
